### PR TITLE
Clean up

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: ["*"]
 
+permissions:
+  contents: write
+
 jobs:
   check_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -54,7 +54,7 @@ jobs:
         id: draft-release
         uses: ./.github/actions/draft-release
         with:
-          token: ${{ secrets.GITHUB_ADMIN_TOKEN }}
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           target: ${{ github.event.inputs.target }}
           branch: ${{ github.event.inputs.branch }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,7 +45,7 @@ jobs:
           TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
         uses: ./.github/actions/publish-release
         with:
-          token: ${{ secrets.GITHUB_ADMIN_TOKEN }}
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           release_url: ${{ github.event.inputs.release_url }}
       - name: "** Next Step **"
         run: |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Prep `jupyter_releaser` fork:
 
 - [ ] Clone this repository onto your GitHub user account.
 - [ ] Add a [GitHub Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions, saved as
-      `GITHUB_ADMIN_TOKEN` in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+      `ADMIN_GITHUB_TOKEN` in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 - [ ] Add access tokens for the test [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github) stored as `TEST_PYPI_TOKEN`
 - [ ] If needed, add access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens), saved as `NPM_TOKEN`.
 
@@ -176,6 +176,8 @@ version_info = get_version_info(__version__)
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+_Note_ The check release action needs `contents: write` [permission](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token).
 
 - [ ] Update or add `RELEASE.md` that describes the onboarding and release process, e.g.
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -53,11 +53,11 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
 
     ignored = []
     for spec in ignore_glob:
-        cmd += f" --ignore-glob {spec}"
+        cmd += f' --ignore-glob "{spec}"'
         ignored.extend(glob(spec, recursive=True))
 
     for spec in ignore_links:
-        cmd += f" --check-links-ignore {spec}"
+        cmd += f' --check-links-ignore "{spec}"'
 
     cmd += " --ignore node_modules"
 
@@ -67,7 +67,7 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
         matched = glob(f"**/*{ext}", recursive=True)
         files.extend(m for m in matched if not m in ignored)
 
-    cmd += " " + " ".join(files)
+    cmd += ' "' + '" "'.join(files) + '"'
 
     try:
         util.run(cmd)

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -250,6 +250,9 @@ def test_check_links(py_package, runner):
     foo = Path(util.CHECKOUT_NAME) / "FOO.md"
     foo.write_text("http://127.0.0.1:5555")
 
+    bar = Path(util.CHECKOUT_NAME) / "BAR BAZ.md"
+    bar.write_text("")
+
     runner(["check-links", "--ignore-glob", "FOO.md"])
 
 


### PR DESCRIPTION
* Updates `check_release` permission to address failure seen in previous [run](https://github.com/jupyter-server/jupyter_releaser/runs/2418709816?check_suite_focus=true) 
* Renames `GITHUB_ADMIN_TOKEN` -> `ADMIN_GITHUB_TOKEN` since the previous one is not a valid secret name (per the GitHub UI)
* Handles checking links of files with spaces in their name
