### PR TITLE
Pre-release clean up

### DIFF
--- a/.github/actions/draft-changelog/action.yml
+++ b/.github/actions/draft-changelog/action.yml
@@ -44,6 +44,8 @@ runs:
         export RH_DRY_RUN=${{ inputs.dry_run }}
         export RH_REF=${GITHUB_REF}
 
+        # Install Jupyter Releaser from git
+        pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1
+
         # Draft Changelog
-        pip install -q jupyter-releaser
         python -m jupyter_releaser.actions.draft_changelog

--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -48,5 +48,8 @@ runs:
         export RH_POST_VERSION_SPEC=${{ inputs.post_version_spec }}
         export RH_DRY_RUN=${{ inputs.dry_run }}
 
+        # Install Jupyter Releaser from git
+        pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1
+
         # Draft Release
         python -m jupyter_releaser.actions.draft_release

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -31,6 +31,8 @@ runs:
         export RH_DRY_RUN=${{ inputs.dry_run }}
         export release_url=${{ inputs.release_url }}
 
+        # Install Jupyter Releaser from git
+        pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1
+
         # Publish release
-        pip install -q jupyter-releaser
         python -m jupyter_releaser.actions.publish_release

--- a/.github/workflows/draft-changelog.yml
+++ b/.github/workflows/draft-changelog.yml
@@ -29,12 +29,9 @@ jobs:
       - name: Upgrade packaging dependencies
         run: |
           pip install --upgrade pip setuptools wheel --user
-      - name: Install Dependencies
-        run: |
-          pip install -e .
       - name: Draft Changelog
         id: draft-changelog
-        uses: ./.github/actions/draft-changelog
+        uses: jupyter-server/jupyter_server/.github/actions/draft-changelog@v1
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -35,12 +35,9 @@ jobs:
       - name: Upgrade packaging dependencies
         run: |
           pip install --upgrade pip setuptools wheel --user
-      - name: Install Dependencies
-        run: |
-          pip install -e .
       - name: Create Draft GitHub Release
         id: draft-release
-        uses: ./.github/actions/draft-release
+        uses: jupyter-server/release_helper/.github/actions/draft-release@v1
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           target: ${{ github.event.inputs.target }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,15 +23,12 @@ jobs:
       - name: Upgrade packaging dependencies
         run: |
           pip install --upgrade pip setuptools wheel --user
-      - name: Install Dependencies
-        run: |
-          pip install -e .
       - name: Publish Release
         id: publish-release
         env:
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }} # use final when ready to publish
           TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-        uses: ./.github/actions/publish-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/publish-release@v1
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           release_url: ${{ github.event.inputs.release_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Local git checkout
 .jupyter_releaser_checkout
+
+# macOS
+.DS_Store

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -75,7 +75,6 @@ def get_version_entry(branch, repo, version, *, auth=None, resolve_backports=Fal
     md = generate_activity_md(
         repo,
         since=since,
-        until=until,
         kind="pr",
         heading_level=2,
         auth=auth,
@@ -87,6 +86,7 @@ def get_version_entry(branch, repo, version, *, auth=None, resolve_backports=Fal
         return f"## {version}\n\nNo merged PRs"
 
     entry = md.replace("[full changelog]", "[Full Changelog]")
+    entry = entry.replace("...None", f"...{until}")
 
     entry = entry.splitlines()[2:]
 

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -53,16 +53,8 @@ def test_get_changelog_version_entry(py_package, mocker):
     mocked_gen.return_value = testutil.CHANGELOG_ENTRY
     branch = "foo"
     resp = changelog.get_version_entry(branch, "bar/baz", version)
-    until = util.run(f'git --no-pager log -n 1 origin/{branch} --pretty=format:"%H"')
-    until = until.replace("%", "")
     mocked_gen.assert_called_with(
-        "bar/baz",
-        since="v0.0.1",
-        kind="pr",
-        branch=branch,
-        heading_level=2,
-        auth=None,
-        until=until,
+        "bar/baz", since="v0.0.1", kind="pr", branch=branch, heading_level=2, auth=None
     )
 
     assert f"## {version}" in resp
@@ -75,7 +67,6 @@ def test_get_changelog_version_entry(py_package, mocker):
     mocked_gen.assert_called_with(
         "bar/baz",
         since="v0.0.1",
-        until=until,
         kind="pr",
         branch=branch,
         heading_level=2,


### PR DESCRIPTION
- Do not pass `until` to `github_activity` since it excludes that commit
- Use `__token__` as the default twine username
- Use `@v1` tag instead of local installs for the manual workflows so the fork is always running the latest from the source `jupyter_releaser`
- Fix bug where `git stash` is applied when there are no changes (which raises an error)
