### PR TITLE
Prep for PyPI Release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,12 @@ on:
       release_url:
         description: "The URL of the draft GitHub release"
         required: true
+      pypi_registry:
+        description: "The PYPI registry"
+        default: https://pypi.org/simple/
+      npm_registry:
+        description: "The npm registry"
+        default: https://registry.npmjs.org/
 jobs:
   publish_release:
     runs-on: ubuntu-latest
@@ -30,8 +36,11 @@ jobs:
       - name: Publish Release
         id: publish-release
         env:
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }} # use final when ready to publish
-          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_REGISTRY: $${{ github.event.inputs.pypi_registry }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_REGISTRY: $${{ github.event.inputs.npm_registry }}
         uses: jupyter-server/jupyter_releaser/.github/actions/publish-release@v1
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -131,10 +131,13 @@ def extract_package(path):
     return data
 
 
-def handle_auth_token(npm_token):
-    """Handle token auth for npm registry"""
+def handle_npm_config(npm_token):
+    """Handle npm_config"""
     npmrc = Path(".npmrc")
-    text = "//registry.npmjs.org/:_authToken={npm_token}"
+    registry = os.environ.get("NPM_REGISTRY", "registry.npmjs.org")
+    text = f"registry={registry}"
+    if npm_token:
+        text += f"\n///{registry}:_authToken={npm_token}"
     if npmrc.exists():
         text = npmrc.read_text(encoding="utf-8") + text
     npmrc.write_text(text, encoding="utf-8")


### PR DESCRIPTION
- Target the production PYPI and NPM servers
- Do not recommend `jupyter_packaging` as a runtime requirement
- Update docs on tokens
- Clean up PyPI setup - allow registry to be set, refactor, only start pypi server if uploading python package
- Allow npm registry to be set, only set config when uploading npm package
- Add docs on keeping the fork up to date
