### PR TITLE
Automated Changelog Entry for 0.1.1 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...844d9e66bb8376f65c23188fa2868b655d2756a7))
+
+### Enhancements made
+
+- Add Support for Since Parameter [#20](https://github.com/jupyter-server/jupyter_releaser/pull/20) ([@jtpio](https://github.com/jtpio))
+- Prep for PyPI Release [#16](https://github.com/jupyter-server/jupyter_releaser/pull/16) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Restore 0.1.0 Changelog entry [#21](https://github.com/jupyter-server/jupyter_releaser/pull/21) ([@blink1073](https://github.com/blink1073))
+- Use raw GitHub Links [#18](https://github.com/jupyter-server/jupyter_releaser/pull/18) ([@blink1073](https://github.com/blink1073))
+- Add forwardport pr screenshot and update publish release screenshot [#17](https://github.com/jupyter-server/jupyter_releaser/pull/17) ([@blink1073](https://github.com/blink1073))
+- Prep for PyPI Release [#16](https://github.com/jupyter-server/jupyter_releaser/pull/16) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-05-04&to=2021-05-12&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2021-05-04..2021-05-12&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Acodecov-commenter+updated%3A2021-05-04..2021-05-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-05-04..2021-05-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...a637305d93becb9f42eed3628b41055d0d44ea18))
@@ -21,8 +47,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-05-04&to=2021-05-05&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2021-05-04..2021-05-05&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Acodecov-commenter+updated%3A2021-05-04..2021-05-05&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-05-04..2021-05-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on master

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | master  |
| Version Spec | 0.1.1 |
