### PR TITLE
Fix Check Release for NPM-Only Packages

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -25,6 +25,12 @@ runs:
         export RH_DRY_RUN=true
         export RH_REF=${GITHUB_REF}
 
+        # check for npm-only package
+        if [[ ! -f setup.py && -f package.json ]]; then
+            export RH_VERSION_SPEC=patch
+            export RH_POST_VERSION_SPEC=
+        fi
+
         if [ ! -z ${GITHUB_BASE_REF} ]; then
           echo "Using GITHUB_BASE_REF: ${GITHUB_BASE_REF}"
           export RH_BRANCH=${GITHUB_BASE_REF}


### PR DESCRIPTION
NPM-Only Packages use `npm version <version_spec>`, and the default value of `0.0.1a0` is not a valid npm version.