### PR TITLE
More Cleanup in Preparation for Usage with Lumino

### DIFF
--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -65,11 +65,11 @@ def get_version_entry(
     str
         A formatted changelog entry with markers
     """
-    tags = util.run(f"git --no-pager tag --sort=-creatordate --merged {branch}")
-    if not tags:  # pragma: no cover
-        raise ValueError(f"No tags found on branch {branch}")
+    if not since:
+        tags = util.run(f"git --no-pager tag --sort=-creatordate --merged {branch}")
+        if tags:
+            since = tags.splitlines()[0]
 
-    since = since or tags.splitlines()[0]
     branch = branch.split("/")[-1]
     util.log(f"Getting changes to {repo} since {since} on branch {branch}...")
 

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -255,11 +255,16 @@ def build_changelog(ref, branch, repo, auth, changelog_path, since, resolve_back
 @add_options(branch_options)
 @add_options(since_options)
 @add_options(auth_options)
+@add_options(changelog_path_options)
 @add_options(dry_run_options)
 @use_checkout_dir()
-def draft_changelog(version_spec, ref, branch, repo, since, auth, dry_run):
+def draft_changelog(
+    version_spec, ref, branch, repo, since, auth, changelog_path, dry_run
+):
     """Create a changelog entry PR"""
-    lib.draft_changelog(version_spec, branch, repo, since, auth, dry_run)
+    lib.draft_changelog(
+        version_spec, branch, repo, since, auth, changelog_path, dry_run
+    )
 
 
 @main.command()

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -72,7 +72,7 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
     files = []
     for ext in [".md", ".rst", ".ipynb"]:
         matched = glob(f"**/*{ext}", recursive=True)
-        files.extend(m for m in matched if not m in ignored)
+        files.extend(m for m in matched if not m in ignored and "node_modules" not in m)
 
     for f in files:
         file_cmd = cmd + f' "{f}"'
@@ -84,7 +84,7 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
                 util.run(file_cmd + " --lf")
 
 
-def draft_changelog(version_spec, branch, repo, since, auth, dry_run):
+def draft_changelog(version_spec, branch, repo, since, auth, changelog_path, dry_run):
     """Create a changelog entry PR"""
     repo = repo or util.get_repo()
     branch = branch or util.get_branch()
@@ -96,6 +96,9 @@ def draft_changelog(version_spec, branch, repo, since, auth, dry_run):
 
     # Check out any unstaged files from version bump
     util.run("git checkout -- .")
+
+    current = changelog.extract_current(changelog_path)
+    util.log(f"\n\nCurrent Changelog Entry:\n{current}")
 
     title = f"{changelog.PR_PREFIX} for {version} on {branch}"
     commit_message = f'git commit -a -m "{title}"'

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -152,7 +152,14 @@ def get_package_versions(version):
         message += f'\nnpm version: {data["name"]}: {data["version"]}'
     if "workspaces" in data:
         message += "\nnpm workspace versions:"
-        packages = data["workspaces"].get("packages", [])
+
+        if isinstance(data["workspaces"], dict):
+            packages = []
+            for value in data["workspaces"].values():
+                packages.extend(value)
+        else:
+            packages = data["workspaces"]
+
         for pattern in packages:
             for path in glob(pattern, recursive=True):
                 text = Path(path).joinpath("package.json").read_text()

--- a/jupyter_releaser/tests/conftest.py
+++ b/jupyter_releaser/tests/conftest.py
@@ -60,7 +60,6 @@ def git_repo(tmp_path):
 
     run("git add .")
     run('git commit -m "foo"')
-    run("git tag v0.0.1")
     run(f"git remote add origin {util.normalize_path(tmp_path)}")
     run("git push origin foo")
     run("git remote set-head origin foo")

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -54,7 +54,7 @@ def test_get_changelog_version_entry(py_package, mocker):
     branch = "foo"
     resp = changelog.get_version_entry(branch, "bar/baz", version)
     mocked_gen.assert_called_with(
-        "bar/baz", since="v0.0.1", kind="pr", branch=branch, heading_level=2, auth=None
+        "bar/baz", since=None, kind="pr", branch=branch, heading_level=2, auth=None
     )
 
     assert f"## {version}" in resp
@@ -66,7 +66,7 @@ def test_get_changelog_version_entry(py_package, mocker):
     )
     mocked_gen.assert_called_with(
         "bar/baz",
-        since="v0.0.1",
+        since=None,
         kind="pr",
         branch=branch,
         heading_level=2,

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     setuptools
     tbump
     toml
+    tomlkit<0.7.1
     twine
 
 [options.extras_require]


### PR DESCRIPTION
* Do not require tags to exist in the branch for changelog generation
* Skip `node_modules` files when checking links
* Print current changelog entry in `draft_changelog`
* Handle `workspaces` metadata being a dict (`jupyterlab` currently) or a list (`lumino` currently)
* Pin `tomlkit` since it `0.7.1` breaks `tbump`