### PR TITLE
Use Releaser to Tag Itself

### DIFF
--- a/.github/scripts/bump_tag.sh
+++ b/.github/scripts/bump_tag.sh
@@ -1,0 +1,7 @@
+set -eux
+
+# Update the v1 tag for GitHub Actions consumers
+if [[ ${RH_DRY_RUN:=true} != 'true' ]]; then
+    git tag -f -a v1 -m "Github Action release"
+    git push origin -f --tags
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
 src = "jupyter_releaser/__init__.py"
+
+[tool.jupyter-releaser.hooks]
+after-draft-release = "bash ./.github/scripts/bump_tag.sh"


### PR DESCRIPTION
Avoids the manual step of updating the `v1` tag for GitHub Actions consumers as part of the release process of `jupyter_releaser`.