### PR TITLE
Automated Changelog Entry for 0.1.6 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@
 ### Maintenance and upkeep improvements
 
 - Properly install NPM Packages [#31](https://github.com/jupyter-server/jupyter_releaser/pull/31) ([@jtpio](https://github.com/jtpio))
-
-### Other merged PRs
-
 - Use Releaser to Tag Itself [#32](https://github.com/jupyter-server/jupyter_releaser/pull/32) ([@afshin](https://github.com/afshin))
 
 ### Contributors to this release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.6
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v0.1.5...1466f348fdaccd6f079f8278f213ca7611011f54))
+
+### Maintenance and upkeep improvements
+
+- Properly install NPM Packages [#31](https://github.com/jupyter-server/jupyter_releaser/pull/31) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Use Releaser to Tag Itself [#32](https://github.com/jupyter-server/jupyter_releaser/pull/32) ([@afshin](https://github.com/afshin))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-05-21&to=2021-05-24&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Aafshin+updated%3A2021-05-21..2021-05-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-05-21..2021-05-24&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.5
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v0.1.4...6499aa163689c110b50ed9e8345969581908d4d9))
@@ -15,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-05-20&to=2021-05-21&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-05-20..2021-05-21&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.4
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.6 on master

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | master  |
| Version Spec | 0.1.6 |
