### PR TITLE
Use the last line of the `npm pack` command

### DIFF
--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -24,7 +24,7 @@ def build_dist(package, dist_dir):
 
     if osp.isdir(package):
         basedir = package
-        tarball = osp.join(package, util.run("npm pack", cwd=package).split('\n')[-1])
+        tarball = osp.join(package, util.run("npm pack", cwd=package).split("\n")[-1])
     else:
         basedir = osp.dirname(package)
         tarball = package

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -24,7 +24,7 @@ def build_dist(package, dist_dir):
 
     if osp.isdir(package):
         basedir = package
-        tarball = osp.join(package, util.run("npm pack", cwd=package))
+        tarball = osp.join(package, util.run("npm pack", cwd=package).split('\n')[-1])
     else:
         basedir = osp.dirname(package)
         tarball = package


### PR DESCRIPTION
To fetch the name of the npm tarball, which should be the last statement of the `npm pack` output.

As noticed in https://github.com/jupyterlab/extension-cookiecutter-ts/issues/162#issuecomment-864242628