### PR TITLE
Fix usage of registry value

### DIFF
--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -131,10 +131,10 @@ def handle_npm_config(npm_token):
     """Handle npm_config"""
     npmrc = Path(".npmrc")
     registry = os.environ.get("NPM_REGISTRY", "https://registry.npmjs.org/")
-    registry = registry.replace("https:", "")
-    registry = registry.replace("http:", "")
     text = f"registry={registry}"
     if npm_token:
+        registry = registry.replace("https:", "")
+        registry = registry.replace("http:", "")
         text += f"\n{registry}:_authToken={npm_token}"
     if npmrc.exists():
         text = npmrc.read_text(encoding="utf-8") + text


### PR DESCRIPTION
Fixes #38.  Follow up to fix a logic error introduced in https://github.com/jupyter-server/jupyter_releaser/pull/34. We must use the given registry value before modifying it for token auth usage.