### PR TITLE
Remove extra dollar sign for registry inputs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,9 +38,9 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
           TWINE_USERNAME: __token__
-          TWINE_REGISTRY: $${{ github.event.inputs.pypi_registry }}
+          TWINE_REGISTRY: ${{ github.event.inputs.pypi_registry }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_REGISTRY: $${{ github.event.inputs.npm_registry }}
+          NPM_REGISTRY: ${{ github.event.inputs.npm_registry }}
         uses: jupyter-server/jupyter_releaser/.github/actions/publish-release@v1
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}


### PR DESCRIPTION
Debugging the failing workflow mentioned in https://github.com/jupyter-server/jupyter_releaser/issues/38 let to log the content of `.npmrc` which looked like the following:

![image](https://user-images.githubusercontent.com/591645/123159945-ea28d380-d46d-11eb-800c-7f9c3f542620.png)

