### PR TITLE
Write .npmrc to dist_dir

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -362,7 +362,7 @@ def publish_assets(dist_dir, npm_token, npm_cmd, twine_cmd, dry_run, use_checkou
         os.environ.setdefault("TWINE_USERNAME", "__token__")
 
     if len(glob(f"{dist_dir}/*.tgz")):
-        npm.handle_npm_config(npm_token)
+        npm.handle_npm_config(npm_token, dist_dir)
 
     found = False
     for path in glob(f"{dist_dir}/*.*"):

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -127,9 +127,9 @@ def extract_package(path):
     return data
 
 
-def handle_npm_config(npm_token):
+def handle_npm_config(npm_token, dist_dir):
     """Handle npm_config"""
-    npmrc = Path(".npmrc")
+    npmrc = Path(dist_dir) / Path(".npmrc")
     registry = os.environ.get("NPM_REGISTRY", "https://registry.npmjs.org/")
     text = f"registry={registry}"
     if npm_token:


### PR DESCRIPTION
Since the publish command is run from `dist_dir`.

And it seems that `npm` would otherwise ignore the `.npmrc` file from a parent folder.