### PR TITLE
Handle missing `version` from `package.json`

### DIFF
--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -145,7 +145,7 @@ def get_package_versions(version):
     """Get the formatted list of npm package names and versions"""
     message = ""
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
-    if data["version"] != version:
+    if data.get("version", "") != version:
         message += f"\nPython version: {version}"
         message += f'\nnpm version: {data["name"]}: {data["version"]}'
     if "workspaces" in data:

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -155,7 +155,7 @@ def get_package_versions(version):
             for path in glob(pattern, recursive=True):
                 text = Path(path).joinpath("package.json").read_text()
                 data = json.loads(text)
-                message += f'\n{data["name"]}: {npm_version}'
+                message += f'\n{data["name"]}: {data.get("version", "")}'
     return message
 
 

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -145,16 +145,17 @@ def get_package_versions(version):
     """Get the formatted list of npm package names and versions"""
     message = ""
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
-    if data.get("version", "") != version:
+    npm_version = data.get("version", "")
+    if npm_version != version:
         message += f"\nPython version: {version}"
-        message += f'\nnpm version: {data["name"]}: {data["version"]}'
+        message += f'\nnpm version: {data["name"]}: {npm_version}'
     if "workspaces" in data:
         message += "\nnpm workspace versions:"
         for pattern in _get_workspace_packages(data):
             for path in glob(pattern, recursive=True):
                 text = Path(path).joinpath("package.json").read_text()
                 data = json.loads(text)
-                message += f'\n{data["name"]}: {data["version"]}'
+                message += f'\n{data["name"]}: {npm_version}'
     return message
 
 


### PR DESCRIPTION
Trying to use the Draft Changelog workflow on a repo with a `version` in the `package.json`, which is common in monorepos.

See this failing run for reference: https://github.com/jtpio/jupyter_releaser/runs/2933424228