### PR TITLE
More fixups

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -194,6 +194,15 @@ changelog_options = (
     ]
 )
 
+npm_install_options = [
+    click.option(
+        "--npm-install-options",
+        envvar="RH_NPM_INSTALL_OPTIONS",
+        default="",
+        help="Options to pass when calling npm install",
+    )
+]
+
 
 def add_options(options):
     """Add extracted common options to a click command"""
@@ -319,13 +328,14 @@ def build_npm(package, dist_dir):
 
 @main.command()
 @add_options(dist_dir_options)
+@add_options(npm_install_options)
 @use_checkout_dir()
-def check_npm(dist_dir):
+def check_npm(dist_dir, npm_install_options):
     """Check npm package"""
     if not osp.exists("./package.json"):
         util.log("Skipping check-npm since there is no package.json file")
         return
-    npm.check_dist(dist_dir)
+    npm.check_dist(dist_dir, npm_install_options)
 
 
 @main.command()
@@ -434,10 +444,11 @@ def delete_release(auth, release_url):
 @add_options(auth_options)
 @add_options(dist_dir_options)
 @add_options(dry_run_options)
+@add_options(npm_install_options)
 @click.argument("release-url", nargs=1)
-def extract_release(auth, dist_dir, dry_run, release_url):
+def extract_release(auth, dist_dir, dry_run, release_url, npm_install_options):
     """Download and verify assets from a draft GitHub release"""
-    lib.extract_release(auth, dist_dir, dry_run, release_url)
+    lib.extract_release(auth, dist_dir, dry_run, release_url, npm_install_options)
 
 
 @main.command()

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -256,7 +256,7 @@ def delete_release(auth, release_url):
     gh.repos.delete_release(release.id)
 
 
-def extract_release(auth, dist_dir, dry_run, release_url):
+def extract_release(auth, dist_dir, dry_run, release_url, npm_install_options):
     """Download and verify assets from a draft GitHub release"""
     match = parse_release_url(release_url)
     owner, repo = match["owner"], match["repo"]
@@ -285,7 +285,7 @@ def extract_release(auth, dist_dir, dry_run, release_url):
             if suffix in [".gz", ".whl"]:
                 python.check_dist(path)
             elif suffix == ".tgz":
-                npm.check_dist(path)
+                npm.check_dist(path, npm_install_options)
             else:
                 util.log(f"Nothing to check for {asset.name}")
 
@@ -484,9 +484,9 @@ def prep_git(ref, branch, repo, auth, username, url, install=True):
 
     # Install the package
     if install:
-        # install python package with test deps
+        # install python package in editable mode with test deps
         if util.SETUP_PY.exists():
-            util.run('pip install ".[test]"')
+            util.run('pip install -e ".[test]"')
 
         # prefer yarn if yarn lock exists
         elif util.YARN_LOCK.exists():

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -100,7 +100,7 @@ def extract_dist(dist_dir, target):
     return names
 
 
-def check_dist(dist_dir):
+def check_dist(dist_dir, install_options):
     """Check npm dist file(s) in a dist dir"""
     tmp_dir = Path(TemporaryDirectory().name)
     os.makedirs(tmp_dir)
@@ -113,7 +113,7 @@ def check_dist(dist_dir):
 
     install_str = " ".join(f"./staging/{name}" for name in names)
 
-    util.run(f"npm install {install_str}", cwd=tmp_dir)
+    util.run(f"npm install {install_options} {install_str}", cwd=tmp_dir)
 
     shutil.rmtree(str(tmp_dir), ignore_errors=True)
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -123,6 +123,7 @@ dist-dir: RH_DIST_DIR
 dry-run: RH_DRY_RUN
 links-expire: RH_LINKS_EXPIRE
 npm-cmd: RH_NPM_COMMAND
+npm-install-options: RH_NPM_INSTALL_OPTIONS
 npm-token: NPM_TOKEN
 output: RH_CHANGELOG_OUTPUT
 post-version-spec: RH_POST_VERSION_SPEC


### PR DESCRIPTION
Seen while working on https://github.com/jupyterlab/jupyterlab/issues/10340

- Install in editable mode to pick up dev assets
- Allow options to be passed to `npm install`, which include `--legacy-peer-deps` for JupyterLab
