### PR TITLE
Fix handling of default version bump

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -19,17 +19,9 @@ runs:
         # Set up env variables
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_REPOSITORY=${GITHUB_REPOSITORY}
-        export RH_VERSION_SPEC=0.0.1a0
-        export RH_POST_VERSION_SPEC=0.1.0.dev0
         export RH_CHANGELOG=${{ inputs.changelog }}
         export RH_DRY_RUN=true
         export RH_REF=${GITHUB_REF}
-
-        # check for npm-only package
-        if [[ ! -f setup.py && -f package.json ]]; then
-            export RH_VERSION_SPEC=patch
-            export RH_POST_VERSION_SPEC=
-        fi
 
         if [ ! -z ${GITHUB_BASE_REF} ]; then
           echo "Using GITHUB_BASE_REF: ${GITHUB_BASE_REF}"

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -114,7 +114,7 @@ version_spec_options = [
     click.option(
         "--version-spec",
         envvar="RH_VERSION_SPEC",
-        required=True,
+        default="",
         help="The new version specifier",
     )
 ]

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -17,6 +17,7 @@ from subprocess import check_output
 from subprocess import PIPE
 
 import toml
+from pkg_resources import parse_version
 
 PYPROJECT = Path("pyproject.toml")
 SETUP_PY = Path("setup.py")
@@ -175,6 +176,14 @@ def bump_version(version_spec, version_cmd=""):
 
     if not version_cmd:  # pragma: no cover
         raise ValueError("Please specify a version bump command to run")
+
+    # Assign default values if not version spec was given
+    if not version_spec:
+        if "tbump" in version_cmd:
+            version = parse_version(get_version())
+            version_spec = f"{version.major}.{version.minor}.{version.micro + 1}"
+        else:
+            version_spec == "patch"
 
     # Bump the version
     run(f"{version_cmd} {version_spec}")


### PR DESCRIPTION
Provide reasonable defaults for version bump but allow it to be overridden.
Needed for jupyterlab/jupyterlab#10340 (https://github.com/jupyterlab/jupyterlab/issues/10340)