### PR TITLE
Handle the case where there are no changes in changelog

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -94,7 +94,11 @@ def draft_changelog(version_spec, branch, repo, since, auth, changelog_path, dry
         raise ValueError(f"Tag v{version} already exists")
 
     # Check out any unstaged files from version bump
-    util.run("git checkout -- .")
+    # If this is an automated changelog PR, there may be no effective changes
+    try:
+        util.run("git checkout -- .")
+    except CalledProcessError as e:
+        util.log(str(e))
 
     current = changelog.extract_current(changelog_path)
     util.log(f"\n\nCurrent Changelog Entry:\n{current}")


### PR DESCRIPTION
Handle the case where there are no changes to the changelog, which can happen when making an automated changelog pull request. Fixes error seen in https://github.com/jupyter-server/jupyter_releaser/actions/runs/1005457462.