### PR TITLE
Pin versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,9 @@ install_requires =
     requests
     requests_cache
     setuptools
-    tbump@git+git://github.com/dmerejkowsky/tbump.git@03988d5d2267ddd4a33b3c4196b05b7f24f0a0a4
-    toml
-    tomlkit
+    tomlkit==0.7.0
+    tbump==6.3.2
+    toml==0.10.2
     twine
 
 [options.extras_require]


### PR DESCRIPTION
Pin versions until a new release of `tbump` with https://github.com/dmerejkowsky/tbump/pull/105 is released.