### PR TITLE
Improve Check Release Isolation

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -33,11 +33,13 @@ runs:
         fi
 
         # Install Jupyter Releaser from git unless we are testing Releaser itself
-        export repo_name=$(echo ${GITHUB_REPOSITORY} | cut -d'/' -f 2)
-        echo "repo name: ${repo_name}"
-        if [ ${repo_name} !=  "jupyter_releaser" ]; then
+        export RH_REPO_NAME=$(echo ${GITHUB_REPOSITORY} | cut -d'/' -f 2)
+        echo "repo name: ${RH_REPO_NAME}"
+        if [ ${RH_REPO_NAME} !=  "jupyter_releaser" ]; then
            pip install git+https://github.com/jupyter-server/jupyter_releaser.git
         fi
+
+        export RH_IS_CHECK_RELEASE=true
 
         # Draft Changelog
         python -m jupyter_releaser.actions.draft_changelog

--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -1,9 +1,38 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import os
+import shutil
+from pathlib import Path
+
+from jupyter_releaser.util import CHECKOUT_NAME
+from jupyter_releaser.util import log
 from jupyter_releaser.util import run
+
+check_release = os.environ.get("RH_IS_CHECK_RELEASE").lower() == "true"
+
+if check_release:
+    log("Handling Check Release action")
+
+    # Extract the changelog
+    changelog_location = os.environ.get("RH_CHANGELOG", "CHANGELOG.md")
+    changelog_location = Path(CHECKOUT_NAME) / changelog_location
+    changelog_text = changelog_location.read_text(encoding="utf-8")
+
+    # Remove the checkout
+    shutil.rmtree(CHECKOUT_NAME)
+
+    # Re-install the parent dir in case it was overshadowed
+    run("pip install -e .")
 
 run("jupyter-releaser prep-git")
 run("jupyter-releaser bump-version")
+
+if check_release:
+    # Override the changelog
+    log("Patching the changelog")
+    log(changelog_text)
+    Path(changelog_location).write_text(changelog_text)
+
 run("jupyter-releaser check-changelog")
 run("jupyter-releaser check-links")
 # Make sure npm comes before python in case it produces


### PR DESCRIPTION
Start with a fresh git checkout after drafting the changelog, to prevent any other state from leaking between `draft_changelog` and `draft_release`.  Extract just the changelog file and insert it into the new checkout directory.

See relevant failure [here](https://github.com/jupyterlab/galata/pull/73/checks?check_run_id=3085102485)