### PR TITLE
Add default for `RH_IS_CHECK_RELEASE`

### DIFF
--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -8,7 +8,7 @@ from jupyter_releaser.util import CHECKOUT_NAME
 from jupyter_releaser.util import log
 from jupyter_releaser.util import run
 
-check_release = os.environ.get("RH_IS_CHECK_RELEASE").lower() == "true"
+check_release = os.environ.get("RH_IS_CHECK_RELEASE", "").lower() == "true"
 
 if check_release:
     log("Handling Check Release action")


### PR DESCRIPTION
Caught when running the Draft Release workflow: https://github.com/jtpio/jupyter_releaser/runs/3086332621?check_suite_focus=true

