### PR TITLE
Even more cleanup

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -4,6 +4,8 @@ on:
     branches: ["*"]
   pull_request:
     branches: ["*"]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   check_release:

--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -5,7 +5,6 @@ from jupyter_releaser.util import run
 run("jupyter-releaser prep-git")
 run("jupyter-releaser bump-version")
 run("jupyter-releaser check-changelog")
-run("jupyter-releaser check-links")
 # Make sure npm comes before python in case it produces
 # files for the python package
 run("jupyter-releaser build-npm")
@@ -13,5 +12,6 @@ run("jupyter-releaser check-npm")
 run("jupyter-releaser build-python")
 run("jupyter-releaser check-python")
 run("jupyter-releaser check-manifest")
+run("jupyter-releaser check-links")
 run("jupyter-releaser tag-release")
 run("jupyter-releaser draft-release")

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -65,7 +65,7 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
     for spec in ignore_links:
         cmd += f' --check-links-ignore "{spec}"'
 
-    cmd += " --ignore node_modules"
+    cmd += " --ignore-glob node_modules"
 
     # Gather all of the markdown, RST, and ipynb files
     files = []
@@ -369,7 +369,7 @@ def publish_assets(dist_dir, npm_token, npm_cmd, twine_cmd, dry_run, use_checkou
         npm.handle_npm_config(npm_token, dist_dir)
 
     found = False
-    for path in glob(f"{dist_dir}/*.*"):
+    for path in sorted(glob(f"{dist_dir}/*.*")):
         name = Path(path).name
         suffix = Path(path).suffix
         if suffix in [".gz", ".whl"]:

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -145,7 +145,8 @@ def create_release_commit(version, dist_dir="dist"):
         path = normalize_path(path)
         sha256 = compute_sha256(path)
         shas[path] = sha256
-        cmd += f' -m "{path}: {sha256}"'
+        name = osp.basename(path)
+        cmd += f' -m "{name}: {sha256}"'
 
     run(cmd)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pytest-check-links>=0.5
     requests
     requests_cache
-    setuptools
+    setuptools~=57.0
     tomlkit==0.7.0
     tbump==6.3.2
     toml==0.10.2


### PR DESCRIPTION
- Pin setuptools to the current major version
- Sort released packages by name
- Only include the dist file name in the release commit message
- Move check link to the end of draft release since it less likely to cause failures and can be long
- Use supported flag name for pytest to avoid warnings
- Add nightly cron job for the check release workflow