### PR TITLE
Automated Changelog Entry for 0.2.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...1d9d22c10864a4ec22465207e46e844a24cc6a7a))
+
+### Bugs fixed
+
+- Add default for `RH_IS_CHECK_RELEASE` [#70](https://github.com/jupyter-server/jupyter_releaser/pull/70) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Even more cleanup [#71](https://github.com/jupyter-server/jupyter_releaser/pull/71) ([@blink1073](https://github.com/blink1073))
+- Improve Check Release Isolation [#68](https://github.com/jupyter-server/jupyter_releaser/pull/68) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-07-08&to=2021-07-16&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2021-07-08..2021-07-16&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Acodecov-commenter+updated%3A2021-07-08..2021-07-16&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-07-08..2021-07-16&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.17
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...16bd7ca4af02310eeb3929d66d950ba44d9b765d))
@@ -15,8 +38,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-07-08&to=2021-07-16&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-07-08..2021-07-16&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.16
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on master

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | master  |
| Version Spec | 0.2.0 |
