### PR TITLE
Use Async Output Where Possible

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -33,10 +33,10 @@ runs:
         fi
 
         # Install Jupyter Releaser from git unless we are testing Releaser itself
-        export RH_REPO_NAME=$(echo ${GITHUB_REPOSITORY} | cut -d'/' -f 2)
-        echo "repo name: ${RH_REPO_NAME}"
-        if [ ${RH_REPO_NAME} !=  "jupyter_releaser" ]; then
-           pip install git+https://github.com/jupyter-server/jupyter_releaser.git
+        if ! command -v jupyter-releaser &> /dev/null
+        then
+            echo "COMMAND could not be found"
+            exit
         fi
 
         export RH_IS_CHECK_RELEASE=true

--- a/LICENSE
+++ b/LICENSE
@@ -25,3 +25,10 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Tee File License
+================
+
+The tee.py file is from https://github.com/pycontribs/subprocess-tee/
+which is licensed under the "MIT" license.  See the tee.py file for details.

--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 from pathlib import Path
+from subprocess import CalledProcessError
 
 from jupyter_releaser.util import CHECKOUT_NAME
 from jupyter_releaser.util import log
@@ -21,8 +22,10 @@ if check_release:
     # Remove the checkout
     shutil.rmtree(CHECKOUT_NAME)
 
-    # Re-install the parent dir if it was overshadowed
-    if os.environ.get("RH_REPO_NAME") == "jupyter_releaser":
+    # Re-install jupyter-releaser if it was overshadowed
+    try:
+        run("jupyter-releaser --help")
+    except CalledProcessError:
         run("pip install -e .")
 
 run("jupyter-releaser prep-git")

--- a/jupyter_releaser/tee.py
+++ b/jupyter_releaser/tee.py
@@ -1,0 +1,170 @@
+"""tee like run implementation."""
+# This file is a modified version of https://github.com/pycontribs/subprocess-tee/blob/daffcbbf49fc5a2c7f3eaf75551f08fac0b9b63d/src/subprocess_tee/__init__.py
+#
+# It is licensed under the following license:
+#
+# The MIT License
+# Copyright (c) 2020 Sorin Sbarnea
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import asyncio
+import os
+import platform
+import subprocess
+import sys
+from asyncio import StreamReader
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Union
+
+if TYPE_CHECKING:
+    CompletedProcess = subprocess.CompletedProcess[Any]  # pylint: disable=E1136
+else:
+    CompletedProcess = subprocess.CompletedProcess
+
+try:
+    from shlex import join  # type: ignore
+except ImportError:
+    from subprocess import list2cmdline as join  # pylint: disable=ungrouped-imports
+
+
+STREAM_LIMIT = 2 ** 23  # 8MB instead of default 64kb, override it if you need
+
+
+async def _read_stream(stream: StreamReader, callback: Callable[..., Any]) -> None:
+    while True:
+        line = await stream.readline()
+        if line:
+            callback(line)
+        else:
+            break
+
+
+async def _stream_subprocess(args: str, **kwargs: Any) -> CompletedProcess:
+    platform_settings: Dict[str, Any] = {}
+    if platform.system() == "Windows":
+        platform_settings["env"] = os.environ
+
+    # this part keeps behavior backwards compatible with subprocess.run
+    tee = kwargs.get("tee", True)
+    stdout = kwargs.get("stdout", sys.stdout)
+    if stdout == subprocess.DEVNULL or not tee:
+        stdout = open(os.devnull, "w")
+    stderr = kwargs.get("stderr", sys.stderr)
+    if stderr == subprocess.DEVNULL or not tee:
+        stderr = open(os.devnull, "w")
+
+    # We need to tell subprocess which shell to use when running shell-like
+    # commands.
+    # * SHELL is not always defined
+    # * /bin/bash does not exit on alpine, /bin/sh seems bit more portable
+    if "executable" not in kwargs and isinstance(args, str) and " " in args:
+        platform_settings["executable"] = os.environ.get("SHELL", "/bin/sh")
+
+    # pass kwargs we know to be supported
+    for arg in ["cwd", "env"]:
+        if arg in kwargs:
+            platform_settings[arg] = kwargs[arg]
+
+    # Some users are reporting that default (undocumented) limit 64k is too
+    # low
+    process = await asyncio.create_subprocess_shell(
+        args,
+        limit=STREAM_LIMIT,
+        stdin=kwargs.get("stdin", False),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        **platform_settings,
+    )
+    out: List[str] = []
+    err: List[str] = []
+
+    def tee_func(line: bytes, sink: List[str], pipe: Optional[Any]) -> None:
+        line_str = line.decode("utf-8").rstrip()
+        sink.append(line_str)
+        if not kwargs.get("quiet", False):
+            # This is modified from the default implementation since
+            # we want all output to be interleved on the same stream
+            print(line_str, file=sys.stderr)
+
+    loop = asyncio.get_event_loop()
+    tasks = []
+    if process.stdout:
+        tasks.append(
+            loop.create_task(
+                _read_stream(process.stdout, lambda l: tee_func(l, out, stdout))
+            )
+        )
+    if process.stderr:
+        tasks.append(
+            loop.create_task(
+                _read_stream(process.stderr, lambda l: tee_func(l, err, stderr))
+            )
+        )
+
+    await asyncio.wait(set(tasks))
+
+    # We need to be sure we keep the stdout/stderr output identical with
+    # the ones procued by subprocess.run(), at least when in text mode.
+    check = kwargs.get("check", False)
+    stdout = None if check else ""
+    stderr = None if check else ""
+    if out:
+        stdout = os.linesep.join(out) + os.linesep
+    if err:
+        stderr = os.linesep.join(err) + os.linesep
+
+    return CompletedProcess(
+        args=args,
+        returncode=await process.wait(),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def run(args: Union[str, List[str]], **kwargs: Any) -> CompletedProcess:
+    """Drop-in replacement for subprocerss.run that behaves like tee.
+    Extra arguments added by our version:
+    echo: False - Prints command before executing it.
+    quiet: False - Avoid printing output
+    """
+    if isinstance(args, str):
+        cmd = args
+    else:
+        # run was called with a list instead of a single item but asyncio
+        # create_subprocess_shell requires command as a single string, so
+        # we need to convert it to string
+        cmd = join(args)
+
+    check = kwargs.get("check", False)
+
+    if kwargs.get("echo", False):
+        # This is modified from the default implementation since
+        # we want all output to be interleved on the same stream
+        print(f"COMMAND: {cmd}", file=sys.stderr)
+
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(_stream_subprocess(cmd, **kwargs))
+
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        )
+    return result


### PR DESCRIPTION
Use https://github.com/pycontribs/subprocess-tee to get asynchronous subprocess output for all platforms but Windows, which does not work well with asynchronous processes in Python.
Also clean up logic for when to install `jupyter-releaser` in the workflows.