### PR TITLE
Add ability to skip steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,14 @@ command options in `cli.py`. The environment variables unique to
 `jupyter-releaser` are prefixed with `RH_`. A list of all env variables can be seen
 by running `jupyter-releaser list-envvars`.
 
-### Default Values, Options, and Hooks
+### Default Values, Options, Skip, and Hooks
 
 The default values can also be overriden using a config file.
 
 Options can be overridden using the `options` section.
+
+You can skip one or more commands using a `skip` section, which is a list of
+commands to skip.
 
 You can also define hooks to run before and after
 commands in a `hooks` section. Hooks can be a shell command to run or
@@ -153,7 +156,9 @@ Example `.jupyter-releaser.toml`:
 
 ```toml
 [options]
-dist_dir = mydist
+dist_dir = "mydist"
+
+skip = ["check-links"]
 
 [hooks]
 before-tag-version = "npm run pre:tag:script"
@@ -163,7 +168,10 @@ Example `pyproject.toml` section:
 
 ```toml
 [tools.jupyter-releaser.options]
-dist_dir = mydist
+dist_dir = "mydist"
+
+[tools.jupyter-releaser]
+skip = ["check-links"]
 
 [tools.jupyter-releaser.hooks]
 after-build-python = ["python scripts/cleanup.py", "python scripts/send_email.py"]
@@ -178,6 +186,7 @@ Example `package.json`:
     "options": {
       "dist_dir": "mydist"
     },
+    "skip": ["check-manifest"],
     "hooks": {
       "before-publish-dist": "npm run pre:publish:dist"
     }

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -50,11 +50,16 @@ class ReleaseHelperGroup(click.Group):
         config = util.read_config()
         hooks = config.get("hooks", {})
         options = config.get("options", {})
+        skip = config.get("skip", [])
 
         # Print a separation header
         util.log(f'\n\n{"-" * 50}')
         util.log(cmd_name)
         util.log(f'{"-" * 50}\n\n')
+
+        if cmd_name in skip or cmd_name.replace("-", "_") in skip:
+            util.log("*** Skipping based on skip config")
+            return
 
         # Handle all of the parameters
         for param in self.commands[cmd_name].get_params(ctx):

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -230,6 +230,19 @@ def test_draft_changelog_full(py_package, mocker, runner, open_mock, git_prep):
     open_mock.assert_called_once()
 
 
+def test_draft_changelog_skip(py_package, mocker, runner, open_mock, git_prep):
+    mock_changelog_entry(py_package, runner, mocker)
+
+    pyproject_path = Path(util.CHECKOUT_NAME) / "pyproject.toml"
+    pyproject = util.toml.loads(pyproject_path.read_text(encoding="utf-8"))
+    pyproject["tool"] = {"jupyter-releaser": dict()}
+    pyproject["tool"]["jupyter-releaser"]["skip"] = ["draft-changelog"]
+    pyproject_path.write_text(util.toml.dumps(pyproject), encoding="utf-8")
+
+    runner(["draft-changelog", "--version-spec", VERSION_SPEC])
+    open_mock.assert_not_called()
+
+
 def test_draft_changelog_dry_run(npm_package, mocker, runner, git_prep):
     mock_changelog_entry(npm_package, runner, mocker)
     runner(["draft-changelog", "--dry-run", "--version-spec", VERSION_SPEC])
@@ -588,7 +601,7 @@ def test_publish_release(npm_dist, runner, mocker, open_mock):
 
 
 def test_config_file(py_package, runner, mocker, git_prep):
-    config = Path(util.CHECKOUT_NAME) / util.jupyter_releaser_CONFIG
+    config = Path(util.CHECKOUT_NAME) / util.JUPYTER_RELEASER_CONFIG
     config.write_text(TOML_CONFIG, encoding="utf-8")
 
     orig_run = util.run
@@ -613,7 +626,7 @@ def test_config_file(py_package, runner, mocker, git_prep):
 
 
 def test_config_file_env_override(py_package, runner, mocker, git_prep):
-    config = Path(util.CHECKOUT_NAME) / util.jupyter_releaser_CONFIG
+    config = Path(util.CHECKOUT_NAME) / util.JUPYTER_RELEASER_CONFIG
     config.write_text(TOML_CONFIG, encoding="utf-8")
 
     orig_run = util.run
@@ -639,7 +652,7 @@ def test_config_file_env_override(py_package, runner, mocker, git_prep):
 
 
 def test_config_file_cli_override(py_package, runner, mocker, git_prep):
-    config = Path(util.CHECKOUT_NAME) / util.jupyter_releaser_CONFIG
+    config = Path(util.CHECKOUT_NAME) / util.JUPYTER_RELEASER_CONFIG
     config.write_text(TOML_CONFIG, encoding="utf-8")
 
     orig_run = util.run

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -139,7 +139,7 @@ def test_get_config_npm(npm_package):
 
 
 def test_get_config_file(git_repo):
-    config = util.jupyter_releaser_CONFIG
+    config = util.JUPYTER_RELEASER_CONFIG
     config.write_text(testutil.TOML_CONFIG, encoding="utf-8")
     config = util.read_config()
     assert config["hooks"]["before-build-python"] == "python setup.py --version"

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -26,7 +26,7 @@ SETUP_PY = Path("setup.py")
 SETUP_CFG = Path("setup.cfg")
 PACKAGE_JSON = Path("package.json")
 YARN_LOCK = Path("yarn.lock")
-jupyter_releaser_CONFIG = Path(".jupyter-releaser.toml")
+JUPYTER_RELEASER_CONFIG = Path(".jupyter-releaser.toml")
 
 BUF_SIZE = 65536
 TBUMP_CMD = "tbump --non-interactive --only-patch"
@@ -245,8 +245,8 @@ def actions_output(name, value):
 
 def read_config():
     """Read the jupyter-releaser config data"""
-    if jupyter_releaser_CONFIG.exists():
-        return toml.loads(jupyter_releaser_CONFIG.read_text(encoding="utf-8"))
+    if JUPYTER_RELEASER_CONFIG.exists():
+        return toml.loads(JUPYTER_RELEASER_CONFIG.read_text(encoding="utf-8"))
 
     if PYPROJECT.exists():
         data = toml.loads(PYPROJECT.read_text(encoding="utf-8"))


### PR DESCRIPTION
Add the ability to skip commands by name.  Can be used to move pieces like `check_link`s to another build to shorten release time.
Can be used to skip problematic sections (for example an `npm-check` in a Python package that would have caused problems).
