### PR TITLE
Allow after-prep-git to work

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -88,6 +88,12 @@ class ReleaseHelperGroup(click.Group):
         super().invoke(ctx)
 
         # Handle after hooks
+
+        # Re-read config if we just did a git checkout
+        if cmd_name == "prep-git":
+            config = util.read_config()
+            hooks = config.get("hooks", {})
+
         after = f"after-{cmd_name}"
         if after in hooks:
             after_hooks = hooks[after]


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_releaser/issues/67, allowing the use of after-git-prep hooks.