### PR TITLE
Add extra changelog check before push

### DIFF
--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -47,4 +47,6 @@ run("jupyter-releaser check-python")
 run("jupyter-releaser check-manifest")
 run("jupyter-releaser check-links")
 run("jupyter-releaser tag-release")
+# Run check changelog again to make sure no new PRs have been merged
+run("jupyter-releaser check-changelog")
 run("jupyter-releaser draft-release")


### PR DESCRIPTION
Add an extra changelog check before pushing commits and tags to ensure no PRs were merged during release process