### PR TITLE
support structured branch name

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -29,7 +29,7 @@ runs:
         else
           # e.g refs/head/foo or refs/tag/bar
           echo "Using GITHUB_REF: ${GITHUB_REF}"
-          export RH_BRANCH=$(echo ${GITHUB_REF} | cut -d'/' -f 3)
+          export RH_BRANCH=$(echo ${GITHUB_REF} | cut -d'/' -f 3-)
         fi
 
         # Install Jupyter Releaser from git unless we are testing Releaser itself


### PR DESCRIPTION
Fix branch names like ft/foo or fix/bar

This happens there for example: https://github.com/fcollonval/lumino/runs/3163528043?check_suite_focus=true

```
+ echo 'Using GITHUB_REF: refs/heads/ft/accordion-panel'
Using GITHUB_REF: refs/heads/ft/accordion-panel
++ cut -d/ -f 3
++ echo refs/heads/ft/accordion-panel
+ export RH_BRANCH=ft
+ RH_BRANCH=ft
```