### PR TITLE
More cleanup of tag lock

### DIFF
--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -36,7 +36,7 @@ run("jupyter-releaser prep-git")
 # Do this before bumping the version
 curr_dir = os.getcwd()
 os.chdir(CHECKOUT_NAME)
-os.environ.setdefault("RH_SINCE", get_latest_tag(os.environ["RH_BRANCH"]))
+os.environ.setdefault("RH_SINCE", get_latest_tag(os.environ["RH_BRANCH"] or ""))
 os.chdir(curr_dir)
 
 run("jupyter-releaser bump-version")


### PR DESCRIPTION
Follow up to jupyter-server/jupyter_releaser#93 to handle the case where there are no tags on the branch.