### PR TITLE
General code base clean up

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -35,7 +35,7 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git
+            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1
         fi
 
         export RH_IS_CHECK_RELEASE=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: requirements-txt-fixer
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v3.0.0a3
+    hooks:
+      - id: pylint
+        args: [--disable=all, --enable=unused-import]

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -67,10 +67,9 @@ def get_version_entry(
     """
     since = since or util.get_latest_tag(branch)
 
-    branch = branch.split("/")[-1]
     util.log(f"Getting changes to {repo} since {since} on branch {branch}...")
 
-    until = util.run(f'git --no-pager log -n 1 origin/{branch} --pretty=format:"%H"')
+    until = util.run(f'git --no-pager log -n 1 {branch} --pretty=format:"%H"')
     until = until.replace("%", "")
 
     md = generate_activity_md(

--- a/jupyter_releaser/tests/conftest.py
+++ b/jupyter_releaser/tests/conftest.py
@@ -3,14 +3,12 @@
 import json
 import os
 import os.path as osp
-import traceback
 from pathlib import Path
 from urllib.request import OpenerDirector
 
 from click.testing import CliRunner
 from pytest import fixture
 
-from jupyter_releaser import changelog
 from jupyter_releaser import cli
 from jupyter_releaser import util
 from jupyter_releaser.tests import util as testutil

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -1,7 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
-import os
 import shutil
 from pathlib import Path
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -106,7 +106,7 @@ def get_branch():
     elif os.environ.get("GITHUB_REF"):
         # GitHub Action Push Event
         # e.g. refs/heads/feature-branch-1
-        branch = os.environ["GITHUB_REF"].split("/")[-1]
+        branch = "/".join(os.environ["GITHUB_REF"].split("/")[2:])
     else:
         branch = run("git branch --show-current")
     return branch


### PR DESCRIPTION
- Fix ability to run `check_release` against a tag by ensuring we are not in a detached head state
- Fix handling of dist outputs in `extract_release`
- Fix handling of changelog for branch name with slashes
- Use explicit URL for local pypi registry
- Enforce no unused imports
- Add tests