### PR TITLE
Add Generate Changelog Workflow

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,0 +1,61 @@
+name: Generate Changelog
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Target Owner/Repo
+        required: true
+      branch:
+        description: The branch or reference name to filter pull requests by
+        required: false
+      convert_to_rst:
+        description: Whether to convert to RST
+        required: false
+      since:
+        description: Use PRs with activity since this date or git reference
+        required: false
+      until:
+        description: Use PRs with activity until this date or git reference
+        required: false
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        python-version: ["3.9"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: "x64"
+      - name: Upgrade packaging dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel --user
+      - name: Install the Python dependencies
+        run: |
+          sudo apt-get install pandoc
+          pip install pypandoc
+          pip install -e .
+      - name: List installed packages
+        run: |
+          pip freeze
+          pip check
+      - name: Generate the Changelog
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export INPUT_BRANCH=${{ github.event.inputs.branch }}
+          export INPUT_SINCE=${{ github.event.inputs.since }}
+          export INPUT_UNTIL=${{ github.event.inputs.until }}
+          export INPUT_CONVERT_TO_RST=${{ github.event.inputs.convert_to_rst }}
+          python -m jupyter_releaser.actions.generate-changelog ${{ github.event.inputs.target }}
+          cat changelog.md
+      - uses: actions/upload-artifact@v2
+        with:
+          name: changelog
+          path: changelog.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,16 @@ jobs:
         if: ${{ matrix.os != 'ubuntu' }}
         run: |
           pytest -vv -s
+      - name: Verify the Generate Changelog Action
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: https://github.com/jupyter-server/jupyter_releaser
+          INPUT_BRANCH: master
+          INPUT_SINCE: v0.3.0
+          INPUT_UNTIL: v0.4.0
+        run: |
+          python -m jupyter_releaser.actions.generate-changelog ${{ env.TARGET }}
+          cat changelog.md
       - name: Coverage
         run: |
           codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           pytest -vv -s
       - name: Verify the Generate Changelog Action
+        if: ${{ matrix.os == 'ubuntu' }}
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET: https://github.com/jupyter-server/jupyter_releaser

--- a/jupyter_releaser/actions/generate-changelog.py
+++ b/jupyter_releaser/actions/generate-changelog.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from pathlib import Path
+
+from jupyter_releaser.changelog import get_version_entry
+
+target = sys.argv[-1]
+branch = os.environ.get("INPUT_BRANCH")
+since = os.environ.get("INPUT_SINCE")
+until = os.environ.get("INPUT_UNTIL")
+convert_to_rst = os.environ.get("INPUT_CONVERT_TO_RST", "")
+
+print("Generating changelog")
+print("target:", target)
+print("branch:", branch)
+print("convert to rst:", convert_to_rst)
+
+output = get_version_entry(branch, target, "current", since=since, until=until)
+if convert_to_rst.lower() == "true":
+    from pypandoc import convert_text
+
+    output = convert_text(output, "rst", "markdown")
+print("\n\n------------------------------")
+print(output, "------------------------------\n\n")
+Path("changelog.md").write_text(output, encoding="utf-8")

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -46,6 +46,7 @@ def get_version_entry(
     version,
     *,
     since=None,
+    until=None,
     auth=None,
     resolve_backports=False,
     remote="origin",
@@ -62,6 +63,8 @@ def get_version_entry(
         The new version
     since: str
         Use PRs with activity since this date or git reference
+    until: str, option
+        Use PRs until this date or git reference
     auth : str, optional
         The GitHub authorization token
     resolve_backports: bool, optional
@@ -84,7 +87,9 @@ def get_version_entry(
 
     util.log(f"Getting changes to {repo} since {since} on branch {branch}...")
 
-    until = util.run(f'git --no-pager log -n 1 {remote}/{branch} --pretty=format:"%H"')
+    until = until or util.run(
+        f'git --no-pager log -n 1 {remote}/{branch} --pretty=format:"%H"'
+    )
     until = until.replace("%", "")
 
     md = generate_activity_md(


### PR DESCRIPTION
Adds a manual workflow to generate a changelog entry
for a repo that either does not use `jupyter_releaser` or
requires a changelog entry for an older release.
Also supports changelogs written in RST.