### PR TITLE
Fix handling of "since" parameter

### DIFF
--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -36,10 +36,14 @@ run("jupyter-releaser prep-git")
 # Capture the "since" argument in case we add tags before the second
 # "Check Changelog"
 # Do this before bumping the version
-curr_dir = os.getcwd()
-os.chdir(CHECKOUT_NAME)
-os.environ.setdefault("RH_SINCE", get_latest_tag(os.environ["RH_BRANCH"]) or "")
-os.chdir(curr_dir)
+if not os.environ.get("RH_SINCE"):
+    curr_dir = os.getcwd()
+    os.chdir(CHECKOUT_NAME)
+    since = get_latest_tag(os.environ["RH_BRANCH"]) or ""
+    if since:
+        log(f"Capturing {since} in RH_SINCE variable")
+        os.environ["RH_SINCE"] = since
+    os.chdir(curr_dir)
 
 run("jupyter-releaser bump-version")
 


### PR DESCRIPTION
Fixes capture of `RH_SINCE` that was disrupted by https://github.com/jupyter-server/jupyter_releaser/pull/106