### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -49,13 +49,15 @@ jobs:
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export INPUT_BRANCH=${{ github.event.inputs.branch }}
-          export INPUT_SINCE=${{ github.event.inputs.since }}
+          export RH_BRANCH=${{ github.event.inputs.branch }}
+          export RH_SINCE=${{ github.event.inputs.since }}
+          export RH_REF=refs/heads/${RH_BRANCH}
+          export RH_REPOSITORY=${{ github.event.inputs.target }}
           export INPUT_UNTIL=${{ github.event.inputs.until }}
           export INPUT_CONVERT_TO_RST=${{ github.event.inputs.convert_to_rst }}
-          python -m jupyter_releaser.actions.generate-changelog ${{ github.event.inputs.target }}
-          cat changelog.md
+          python -m jupyter_releaser.actions.generate-changelog
+          cat CHANGELOG_ENTRY.md
       - uses: actions/upload-artifact@v2
         with:
           name: changelog
-          path: changelog.md
+          path: CHANGELOG_ENTRY.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,13 +123,17 @@ jobs:
         if: ${{ matrix.os == 'ubuntu' }}
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET: https://github.com/jupyter-server/jupyter_releaser
-          INPUT_BRANCH: master
-          INPUT_SINCE: v0.3.0
+          RH_REPOSITORY: jupyter-server/jupyter_releaser
+          RH_BRANCH: master
+          RU_SINCE: v0.3.0
           INPUT_UNTIL: v0.4.0
         run: |
-          python -m jupyter_releaser.actions.generate-changelog ${{ env.TARGET }}
-          cat changelog.md
+          set -eux
+          python -m jupyter_releaser.actions.generate-changelog
+          cat CHANGELOG_ENTRY.md
+          # Check for version entry in between the two versions and one outside
+          cat CHANGELOG_ENTRY.md | grep -q "#95"
+          cat CHANGELOG_ENTRY.md | grep -q "compare/0.3.3...v0.4.0"
       - name: Coverage
         run: |
           codecov

--- a/jupyter_releaser/actions/draft_changelog.py
+++ b/jupyter_releaser/actions/draft_changelog.py
@@ -1,25 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import os
-
-from jupyter_releaser.util import CHECKOUT_NAME
-from jupyter_releaser.util import get_latest_tag
-from jupyter_releaser.util import log
 from jupyter_releaser.util import run
 
 run("jupyter-releaser prep-git")
-
-# Capture the "since" argument in case we add tags befor checking changelog
-# Do this before bumping the version
-if not os.environ.get("RH_SINCE"):
-    curr_dir = os.getcwd()
-    os.chdir(CHECKOUT_NAME)
-    since = get_latest_tag(os.environ["RH_BRANCH"]) or ""
-    if since:
-        log(f"Capturing {since} in RH_SINCE variable")
-        os.environ["RH_SINCE"] = since
-    os.chdir(curr_dir)
-
 run("jupyter-releaser bump-version")
 run("jupyter-releaser build-changelog")
 run("jupyter-releaser draft-changelog")

--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -7,7 +7,6 @@ from subprocess import CalledProcessError
 
 from jupyter_releaser.changelog import extract_current
 from jupyter_releaser.util import CHECKOUT_NAME
-from jupyter_releaser.util import get_latest_tag
 from jupyter_releaser.util import log
 from jupyter_releaser.util import run
 
@@ -32,18 +31,6 @@ if check_release:
         run("pip install -q -e .")
 
 run("jupyter-releaser prep-git")
-
-# Capture the "since" argument in case we add tags befor checking changelog
-# Do this before bumping the version
-if not os.environ.get("RH_SINCE"):
-    curr_dir = os.getcwd()
-    os.chdir(CHECKOUT_NAME)
-    since = get_latest_tag(os.environ["RH_BRANCH"]) or ""
-    if since:
-        log(f"Capturing {since} in RH_SINCE variable")
-        os.environ["RH_SINCE"] = since
-    os.chdir(curr_dir)
-
 run("jupyter-releaser bump-version")
 
 if check_release:

--- a/jupyter_releaser/actions/generate-changelog.py
+++ b/jupyter_releaser/actions/generate-changelog.py
@@ -1,12 +1,14 @@
 import os
-import sys
 from pathlib import Path
 
 from jupyter_releaser.changelog import get_version_entry
+from jupyter_releaser.util import CHECKOUT_NAME
+from jupyter_releaser.util import run
 
-target = sys.argv[-1]
-branch = os.environ.get("INPUT_BRANCH")
-since = os.environ.get("INPUT_SINCE")
+target = os.environ.get("RH_REPOSITORY")
+branch = os.environ.get("RH_BRANCH")
+ref = os.environ.get("RH_REF")
+since = os.environ.get("RH_SINCE")
 until = os.environ.get("INPUT_UNTIL")
 convert_to_rst = os.environ.get("INPUT_CONVERT_TO_RST", "")
 
@@ -15,11 +17,16 @@ print("target:", target)
 print("branch:", branch)
 print("convert to rst:", convert_to_rst)
 
-output = get_version_entry(branch, target, "current", since=since, until=until)
+run("jupyter-releaser prep-git")
+orig_dir = os.getcwd()
+os.chdir(CHECKOUT_NAME)
+output = get_version_entry(ref, branch, target, "current", since=since, until=until)
+
 if convert_to_rst.lower() == "true":
     from pypandoc import convert_text
 
     output = convert_text(output, "rst", "markdown")
 print("\n\n------------------------------")
 print(output, "------------------------------\n\n")
-Path("changelog.md").write_text(output, encoding="utf-8")
+os.chdir(orig_dir)
+Path("CHANGELOG_ENTRY.md").write_text(output, encoding="utf-8")

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -278,7 +278,9 @@ def bump_version(version_spec, version_cmd):
 @use_checkout_dir()
 def build_changelog(ref, branch, repo, auth, changelog_path, since, resolve_backports):
     """Build changelog entry"""
-    changelog.build_entry(branch, repo, auth, changelog_path, since, resolve_backports)
+    changelog.build_entry(
+        ref, branch, repo, auth, changelog_path, since, resolve_backports
+    )
 
 
 @main.command()
@@ -309,7 +311,7 @@ def check_changelog(
 ):
     """Check changelog entry"""
     changelog.check_entry(
-        branch, repo, auth, changelog_path, since, resolve_backports, output
+        ref, branch, repo, auth, changelog_path, since, resolve_backports, output
     )
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -298,13 +298,19 @@ def extract_release(auth, dist_dir, dry_run, release_url, npm_install_options):
             with open(path, "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
-            suffix = Path(asset.name).suffix
-            if suffix in [".gz", ".whl"]:
-                python.check_dist(path)
-            elif suffix == ".tgz":
-                npm.check_dist(path, npm_install_options)
-            else:
-                util.log(f"Nothing to check for {asset.name}")
+
+    # Check all npm packages
+    npm.check_dist(dist, npm_install_options)
+
+    # Check python packages individually
+    for asset in assets:
+        suffix = Path(asset.name).suffix
+        if suffix in [".gz", ".whl"]:
+            python.check_dist(path)
+        elif suffix == ".tgz":
+            pass  # already handled
+        else:
+            util.log(f"Nothing to check for {asset.name}")
 
     # Skip sha validation for dry runs since the remote tag will not exist
     if dry_run:

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -53,9 +53,16 @@ def test_get_changelog_version_entry(py_package, mocker):
     mocked_gen = mocker.patch("jupyter_releaser.changelog.generate_activity_md")
     mocked_gen.return_value = testutil.CHANGELOG_ENTRY
     branch = "foo"
-    resp = changelog.get_version_entry(branch, "bar/baz", version)
+    ref = "origin/bar/baz"
+    resp = changelog.get_version_entry(ref, branch, "bar/baz", version)
     mocked_gen.assert_called_with(
-        "bar/baz", since=None, kind="pr", branch=branch, heading_level=2, auth=None
+        "bar/baz",
+        since=None,
+        until=None,
+        kind="pr",
+        branch=branch,
+        heading_level=2,
+        auth=None,
     )
 
     assert f"## {version}" in resp
@@ -63,11 +70,12 @@ def test_get_changelog_version_entry(py_package, mocker):
 
     mocked_gen.return_value = testutil.CHANGELOG_ENTRY
     resp = changelog.get_version_entry(
-        branch, "bar/baz", version, resolve_backports=True, auth="bizz"
+        ref, branch, "bar/baz", version, resolve_backports=True, auth="bizz"
     )
     mocked_gen.assert_called_with(
         "bar/baz",
         since=None,
+        until=None,
         kind="pr",
         branch=branch,
         heading_level=2,


### PR DESCRIPTION
- Fix generate changelog workflow by using a git checkout of the repo
- Fix handling of `since` parameter in changelog by using source ref instead of local branch name and remove
hacky workaround of storing the `RH_SINCE` value
- Check all npm packages at once in `extract_release`