### PR TITLE
Remove "Release" from the GitHub Release title

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -240,7 +240,7 @@ def draft_release(
     release = gh.create_release(
         f"v{version}",
         branch,
-        f"Release v{version}",
+        f"v{version}",
         body,
         True,
         prerelease,


### PR DESCRIPTION
This is more of a personal preference, but maybe we could drop the "Release" prefix in the GitHub Release title?

![image](https://user-images.githubusercontent.com/591645/132237326-cfe28e40-4893-4832-b804-00d422a0834c.png)
