### PR TITLE
Make tag name configurable

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -345,7 +345,7 @@ def check_python(dist_dir):
 def build_npm(package, dist_dir):
     """Build npm package"""
     if not osp.exists("./package.json"):
-        util.log("Skipping check-npm since there is no package.json file")
+        util.log("Skipping build-npm since there is no package.json file")
         return
     npm.build_dist(package, dist_dir)
 
@@ -411,6 +411,12 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
     help="The message to use for the release commit",
 )
 @click.option(
+    "--tag-format",
+    envvar="RH_TAG_FORMAT",
+    default="v{version}",
+    help="The format to use for the release tag",
+)
+@click.option(
     "--tag-message",
     envvar="RH_TAG_MESSAGE",
     default="Release {tag_name}",
@@ -422,9 +428,13 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
     help="Whether to skip tagging npm workspace packages",
 )
 @use_checkout_dir()
-def tag_release(dist_dir, release_message, tag_message, no_git_tag_workspace):
+def tag_release(
+    dist_dir, release_message, tag_format, tag_message, no_git_tag_workspace
+):
     """Create release commit and tag"""
-    lib.tag_release(dist_dir, release_message, tag_message, no_git_tag_workspace)
+    lib.tag_release(
+        dist_dir, release_message, tag_format, tag_message, no_git_tag_workspace
+    )
 
 
 @main.command()

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -169,7 +169,9 @@ def make_changelog_pr(auth, branch, repo, title, commit_message, body, dry_run=F
     util.actions_output("pr_url", pull.html_url)
 
 
-def tag_release(dist_dir, release_message, tag_message, no_git_tag_workspace):
+def tag_release(
+    dist_dir, release_message, tag_format, tag_message, no_git_tag_workspace
+):
     """Create release commit and tag"""
     # Get the new version
     version = util.get_version()
@@ -178,8 +180,8 @@ def tag_release(dist_dir, release_message, tag_message, no_git_tag_workspace):
     util.create_release_commit(version, release_message, dist_dir)
 
     # Create the annotated release tag
-    tag_name = f"v{version}"
-    tag_message = tag_message.format(tag_name=tag_name)
+    tag_name = tag_format.format(version=version)
+    tag_message = tag_message.format(tag_name=tag_name, version=version)
     util.run(f'git tag {tag_name} -a -m "{tag_message}"')
 
     # Create release tags for workspace packages if given

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -166,6 +166,7 @@ release-message: RH_RELEASE_MESSAGE
 repo: RH_REPOSITORY
 resolve-backports: RH_RESOLVE_BACKPORTS
 since: RH_SINCE
+tag-format: RH_TAG_FORMAT
 tag-message: RH_TAG_MESSAGE
 twine-cmd: TWINE_COMMAND
 username: GITHUB_ACTOR


### PR DESCRIPTION
Make the tag name used for the release configurable.
Also fix a log message that was using the wrong step name.