### PR TITLE
Add support for PYPI token map

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Publish Release
         id: publish-release
         env:
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_TOKEN_MAP: ${{ secrets.PYPI_TOKEN_MAP }}
           TWINE_USERNAME: __token__
           TWINE_REGISTRY: ${{ github.event.inputs.pypi_registry }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -203,7 +203,13 @@ A. Prep the `jupyter_releaser` fork:
       `ADMIN_GITHUB_TOKEN` in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 - [ ] Add access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github) stored as `PYPI_TOKEN`.
       _Note_ For security reasons, it is recommended that you scope the access
-      to a single repository, and update the value of `PYPI_TOKEN` for each repository that you are releasing.
+      to a single repository, and use a variable called `PYPI_TOKEN_MAP` that is formatted as follows:
+
+      ```
+      owner1/repo1,token1
+      owner2/repo2,token2
+      ```
+
 - [ ] If needed, add access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens), saved as `NPM_TOKEN`.
 
 B. Prep target repository:

--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -4,6 +4,17 @@ import os
 
 from jupyter_releaser.util import run
 
+# First extract the pypi token
+twine_pwd = os.environ.get("PYPI_TOKEN")
+pypi_token_map = os.environ.get("PYPI_TOKEN_MAP", "").replace(r"\n", "\n")
+if pypi_token_map:
+    for line in pypi_token_map.splitlines():
+        name, _, token = line.partition(",")
+        if name == os.environ["RH_REPOSITORY"]:
+            twine_pwd = token
+os.environ["TWINE_PASSWORD"] = token
+
+
 release_url = os.environ["release_url"]
 run(f"jupyter-releaser extract-release {release_url}")
 run(f"jupyter-releaser forwardport-changelog {release_url}")


### PR DESCRIPTION
Fixes #36 

Use a token map to map github repos to pypi tokens.