### PR TITLE
Add Since Last Stable Option for Changelog

### DIFF
--- a/.github/actions/draft-changelog/action.yml
+++ b/.github/actions/draft-changelog/action.yml
@@ -24,6 +24,9 @@ inputs:
   since:
     description: Use PRs with activity since this date or git reference
     required: false
+  since_last_stable:
+    description: Use PRs with activity since the last stable git tag
+    required: false
 outputs:
   pr_url:
     description: "The URL of the Changelog Pull Request"
@@ -47,6 +50,7 @@ runs:
         export RH_DRY_RUN=${{ inputs.dry_run }}
         export RH_REF=${GITHUB_REF}
         export RH_SINCE=${{ inputs.since }}
+        export RH_SINCE_LAST_STABLE=${{ inputs.since_last_stable }}
 
         # Install Jupyter Releaser from git
         pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1

--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -16,16 +16,15 @@ inputs:
   post_version_spec:
     description: "Post Version Specifier"
     required: false
-  changelog:
-    description: "Changelog file"
-    default: "CHANGELOG.md"
-    required: false
   dry_run:
     description: "If set, do not push permanent changes"
     default: "false"
     required: false
   since:
     description: Use PRs with activity since this date or git reference
+    required: false
+  since_last_stable:
+    description: Use PRs with activity since the last stable git tag
     required: false
 outputs:
   release_url:
@@ -47,10 +46,10 @@ runs:
         fi
         export RH_REF=${GITHUB_REF}
         export RH_VERSION_SPEC=${{ inputs.version_spec }}
-        export RH_CHANGELOG=${{ inputs.changelog }}
         export RH_POST_VERSION_SPEC=${{ inputs.post_version_spec }}
         export RH_DRY_RUN=${{ inputs.dry_run }}
         export RH_SINCE=${{ inputs.since }}
+        export RH_SINCE_LAST_STABLE=$${{ inputs.since_last_stable }}
 
         # Install Jupyter Releaser from git
         pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1

--- a/.github/workflows/draft-changelog.yml
+++ b/.github/workflows/draft-changelog.yml
@@ -14,6 +14,9 @@ on:
       since:
         description: Use PRs with activity since this date or git reference
         required: false
+      since_last_stable:
+        description: Use PRs with activity since the last stable git tag
+        required: false
 jobs:
   changelog:
     runs-on: ubuntu-latest
@@ -45,6 +48,7 @@ jobs:
           target: ${{ github.event.inputs.target }}
           branch: ${{ github.event.inputs.branch }}
           since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.intputs.since_last_stable }}
       - name: "** Next Step **"
         run: |
           echo "Review PR: ${{ steps.draft-changelog.outputs.pr_url }}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -17,6 +17,9 @@ on:
       since:
         description: Use PRs with activity since this date or git reference
         required: false
+      since_last_stable:
+        description: Use PRs with activity since the last stable git tag
+        required: false
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -52,6 +55,7 @@ jobs:
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.intputs.since_last_stable }}
       - name: "** Next Step **"
         run: |
           echo "Run the "Publish Release" Workflow with Release Url:"

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -198,7 +198,13 @@ since_options = [
         envvar="RH_SINCE",
         default=None,
         help="Use PRs with activity since this date or git reference",
-    )
+    ),
+    click.option(
+        "--since-last-stable",
+        is_flag=True,
+        envvar="RH_SINCE_LAST_STABLE",
+        help="Use PRs with activity since the last stable git tag",
+    ),
 ]
 
 changelog_options = (
@@ -276,10 +282,19 @@ def bump_version(version_spec, version_cmd):
 @main.command()
 @add_options(changelog_options)
 @use_checkout_dir()
-def build_changelog(ref, branch, repo, auth, changelog_path, since, resolve_backports):
+def build_changelog(
+    ref, branch, repo, auth, changelog_path, since, since_last_stable, resolve_backports
+):
     """Build changelog entry"""
     changelog.build_entry(
-        ref, branch, repo, auth, changelog_path, since, resolve_backports
+        ref,
+        branch,
+        repo,
+        auth,
+        changelog_path,
+        since,
+        since_last_stable,
+        resolve_backports,
     )
 
 
@@ -292,11 +307,26 @@ def build_changelog(ref, branch, repo, auth, changelog_path, since, resolve_back
 @add_options(dry_run_options)
 @use_checkout_dir()
 def draft_changelog(
-    version_spec, ref, branch, repo, since, auth, changelog_path, dry_run
+    version_spec,
+    ref,
+    branch,
+    repo,
+    since,
+    since_last_stable,
+    auth,
+    changelog_path,
+    dry_run,
 ):
     """Create a changelog entry PR"""
     lib.draft_changelog(
-        version_spec, branch, repo, since, auth, changelog_path, dry_run
+        version_spec,
+        branch,
+        repo,
+        since,
+        since_last_stable,
+        auth,
+        changelog_path,
+        dry_run,
     )
 
 
@@ -307,11 +337,27 @@ def draft_changelog(
 )
 @use_checkout_dir()
 def check_changelog(
-    ref, branch, repo, auth, changelog_path, since, resolve_backports, output
+    ref,
+    branch,
+    repo,
+    auth,
+    changelog_path,
+    since,
+    since_last_stable,
+    resolve_backports,
+    output,
 ):
     """Check changelog entry"""
     changelog.check_entry(
-        ref, branch, repo, auth, changelog_path, since, resolve_backports, output
+        ref,
+        branch,
+        repo,
+        auth,
+        changelog_path,
+        since,
+        since_last_stable,
+        resolve_backports,
+        output,
     )
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -83,7 +83,9 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
                 util.run(file_cmd + " --lf", shell=False)
 
 
-def draft_changelog(version_spec, branch, repo, since, auth, changelog_path, dry_run):
+def draft_changelog(
+    version_spec, branch, repo, since, since_last_stable, auth, changelog_path, dry_run
+):
     """Create a changelog entry PR"""
     repo = repo or util.get_repo()
     branch = branch or util.get_branch()
@@ -124,7 +126,9 @@ def draft_changelog(version_spec, branch, repo, since, auth, changelog_path, dry
 | Branch  | {branch}  |
 | Version Spec | {version_spec} |
 """
-    if since:
+    if since_last_stable:
+        body += "| Since Last Stable | true |"
+    elif since:
         body += f"| Since | {since} |"
     util.log(body)
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -166,6 +166,7 @@ release-message: RH_RELEASE_MESSAGE
 repo: RH_REPOSITORY
 resolve-backports: RH_RESOLVE_BACKPORTS
 since: RH_SINCE
+since-last-stable: RH_SINCE_LAST_STABLE
 tag-format: RH_TAG_FORMAT
 tag-message: RH_TAG_MESSAGE
 twine-cmd: TWINE_COMMAND
@@ -315,13 +316,23 @@ def test_draft_changelog_skip(py_package, mocker, runner, open_mock, git_prep):
     config["skip"] = ["draft-changelog"]
     config_path.write_text(util.toml.dumps(config), encoding="utf-8")
 
-    runner(["draft-changelog", "--version-spec", VERSION_SPEC])
+    runner(["draft-changelog", "--version-spec", VERSION_SPEC, "--since", "foo"])
     open_mock.assert_not_called()
 
 
 def test_draft_changelog_dry_run(npm_package, mocker, runner, git_prep):
     mock_changelog_entry(npm_package, runner, mocker)
-    runner(["draft-changelog", "--dry-run", "--version-spec", VERSION_SPEC])
+    os.environ["RH_SINCE_LAST_STABLE"] = "true"
+    runner(
+        [
+            "draft-changelog",
+            "--dry-run",
+            "--version-spec",
+            VERSION_SPEC,
+            "--since-last-stable",
+        ]
+    )
+    del os.environ["RH_SINCE_LAST_STABLE"]
 
 
 def test_draft_changelog_lerna(workspace_package, mocker, runner, open_mock, git_prep):

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -87,6 +87,33 @@ def test_get_changelog_version_entry(py_package, mocker):
     assert testutil.PR_ENTRY in resp
 
 
+def test_get_changelog_version_entry_since_last_stable(py_package, mocker):
+    version = util.get_version()
+
+    mocked_gen = mocker.patch("jupyter_releaser.changelog.generate_activity_md")
+    mocked_gen.return_value = testutil.CHANGELOG_ENTRY
+    branch = "foo"
+    util.run("git branch baz/bar")
+    util.run("git tag v1.0.0 baz/bar")
+    util.run("git tag v1.1.0a0 baz/bar")
+    ref = "heads/baz/bar"
+    resp = changelog.get_version_entry(
+        ref, branch, "baz/bar", version, since_last_stable=True
+    )
+    mocked_gen.assert_called_with(
+        "baz/bar",
+        since="v1.0.0",
+        until=None,
+        kind="pr",
+        branch=branch,
+        heading_level=2,
+        auth=None,
+    )
+
+    assert f"## {version}" in resp
+    assert testutil.PR_ENTRY in resp
+
+
 def test_compute_sha256(py_package):
     assert len(util.compute_sha256(py_package / "CHANGELOG.md")) == 64
 


### PR DESCRIPTION
Add an option to use PRs with activity since the last stable git tag. This is useful for creating the first alpha release or first final release in a release cycle.