### PR TITLE
Automated Changelog Entry for 0.7.1 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,20 @@
 
 ## 0.7.1
 
-([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...9d99303083ef72f25a40bbf940bf29099ac8fca0))
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...00b07713e91443b84f5efbf554449b0c6b08e5a6))
 
 ### Bugs fixed
 
+- Fix typo in the draft release action [#157](https://github.com/jupyter-server/jupyter_releaser/pull/157) ([@jtpio](https://github.com/jtpio))
 - Fix handling of PYPI token map [#155](https://github.com/jupyter-server/jupyter_releaser/pull/155) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
 
 ### Contributors to this release
 
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-09-13&to=2021-09-13&type=c))
 
-[@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-09-13..2021-09-13&type=Issues)
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2021-09-13..2021-09-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-09-13..2021-09-13&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 


### PR DESCRIPTION
Automated Changelog Entry for 0.7.1 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | master  |
| Version Spec | 0.7.1 |
| Since | v1 |