### PR TITLE
Automated Changelog Entry for 0.7.4 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.7.4
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...ccd4eb7cfa280079745730af7c5d7b297f243801))
+
+### Bugs fixed
+
+- Fix Handling of Since Last Stable [#163](https://github.com/jupyter-server/jupyter_releaser/pull/163) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-09-15&to=2021-09-15&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-09-15..2021-09-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.7.3
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...98d6e21224c6a39e2e1467e1b4a2bd9d95448cb4))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-09-13&to=2021-09-15&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ajtpio+updated%3A2021-09-13..2021-09-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.7.2
 


### PR DESCRIPTION
Automated Changelog Entry for 0.7.4 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | master  |
| Version Spec | 0.7.4 |
| Since | v1 |