### PR TITLE
Escape the npm version string in PR text

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -116,7 +116,7 @@ def draft_changelog(
     body = title
 
     if npm_versions:
-        body += npm_versions
+        body += f"```\n{npm_versions}\n```"
 
     body += '\n\nAfter merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs'
     body += f"""


### PR DESCRIPTION
Avoid accidentally printing a version that is a valid GitHub team or user name, e.g. `@jupyterlab-toc-extension`

