### PR TITLE
Fix escaping of the changelog comment

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -116,7 +116,7 @@ def draft_changelog(
     body = title
 
     if npm_versions:
-        body += f"\n```\n{npm_versions}\n```"
+        body += f"\n```{npm_versions}\n```"
 
     body += '\n\nAfter merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs'
     body += f"""


### PR DESCRIPTION
Follow-up to https://github.com/jupyter-server/jupyter_releaser/pull/177 to fix https://github.com/jupyter-server/jupyter_releaser/pull/177#issuecomment-939843870