### PR TITLE
Add ability to skip steps

### DIFF
--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -26,10 +26,15 @@ inputs:
   since_last_stable:
     description: Use PRs with activity since the last stable git tag
     required: false
+  steps_to_skip:
+    description: comma-separated list of steps to steps_to_skip
+    required: false
+
 outputs:
   release_url:
     description: "The html URL of the draft GitHub release"
     value: ${{ steps.draft-release.outputs.release_url }}
+
 runs:
   using: "composite"
   steps:
@@ -50,6 +55,7 @@ runs:
         export RH_DRY_RUN=${{ inputs.dry_run }}
         export RH_SINCE=${{ inputs.since }}
         export RH_SINCE_LAST_STABLE=${{ inputs.since_last_stable }}
+        export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
 
         # Install Jupyter Releaser from git
         pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "If set, do not push permanent changes"
     default: "false"
     required: false
+  steps_to_skip:
+    description: comma-separated list of steps to steps_to_skip
+    required: false
+
 outputs:
   release_url:
     description: "The html URL of the GitHub release"
@@ -18,6 +22,7 @@ outputs:
   pr_url:
     description: "The html URL of the forwardport PR if applicable"
     value: ${{ steps.publish-release.outputs.pr_url }}
+
 runs:
   using: "composite"
   steps:
@@ -30,6 +35,7 @@ runs:
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_DRY_RUN=${{ inputs.dry_run }}
         export release_url=${{ inputs.release_url }}
+        export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
 
         # Install Jupyter Releaser from git
         pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -20,6 +20,9 @@ on:
       since_last_stable:
         description: Use PRs with activity since the last stable git tag
         required: false
+      steps_to_skip:
+        description: comma-separated list of steps to steps_to_skip
+        required: false
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -57,6 +60,7 @@ jobs:
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
       - name: "** Next Step **"
         run: |
           echo "Run the "Publish Release" Workflow with Release Url:"

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -20,6 +20,9 @@ on:
       since_last_stable:
         description: Use PRs with activity since the last stable git tag
         required: false
+      steps_to_skip:
+        description: comma-separated list of steps to steps_to_skip
+        required: false
 
 jobs:
   release:
@@ -58,6 +61,7 @@ jobs:
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.intputs.since_last_stable }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
 
       - name: Publish Release
         id: publish-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,9 @@ on:
       release_url:
         description: "The URL of the draft GitHub release"
         required: true
+      steps_to_skip:
+        description: comma-separated list of steps to steps_to_skip
+        required: false
 jobs:
   publish_release:
     runs-on: ubuntu-latest
@@ -38,6 +41,7 @@ jobs:
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
       - name: "** Next Step **"
         run: |
           echo "Verify the final release"

--- a/docs/source/reference/faq.md
+++ b/docs/source/reference/faq.md
@@ -8,3 +8,8 @@ Create a new manual PR to fix the PR and re-orient the changelog entry markers.
 
 The release will fail to push commits because it will not be up to date. Delete the pushed tags and re-start with "Draft Changelog" to
 pick up the new PR.
+
+## What happens if one of my steps is failing but I want to force a release?
+
+This could happen for example if you need to override PRs to include in the changelog. In that case you would pass "check-changlog" to the
+workflow's "steps_to_skip" input option.

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -51,9 +51,12 @@ class ReleaseHelperGroup(click.Group):
         hooks = config.get("hooks", {})
         options = config.get("options", {})
         skip = config.get("skip", [])
+
         if "--force" in ctx.args:
             skip = []
             ctx.args.remove("--force")
+
+        skip += os.environ.get("RH_STEPS_TO_SKIP", "").split(",")
 
         # Print a separation header
         util.log(f'\n\n{"-" * 50}')

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -311,7 +311,7 @@ def test_draft_changelog_full(py_package, mocker, runner, open_mock, git_prep):
     open_mock.assert_called_once()
 
 
-def test_draft_changelog_skip(py_package, mocker, runner, open_mock, git_prep):
+def test_draft_changelog_skip_config(py_package, mocker, runner, open_mock, git_prep):
     mock_changelog_entry(py_package, runner, mocker)
 
     config_path = Path(util.CHECKOUT_NAME) / util.JUPYTER_RELEASER_CONFIG
@@ -321,6 +321,19 @@ def test_draft_changelog_skip(py_package, mocker, runner, open_mock, git_prep):
 
     runner(["draft-changelog", "--version-spec", VERSION_SPEC, "--since", "foo"])
     open_mock.assert_not_called()
+
+
+def test_draft_changelog_skip_environ(py_package, mocker, runner, open_mock, git_prep):
+    mock_changelog_entry(py_package, runner, mocker)
+
+    config_path = Path(util.CHECKOUT_NAME) / util.JUPYTER_RELEASER_CONFIG
+    config = util.toml.loads(config_path.read_text(encoding="utf-8"))
+    os.environ["RH_STEPS_TO_SKIP"] = "draft-changelog,other-fake-step"
+    config_path.write_text(util.toml.dumps(config), encoding="utf-8")
+
+    runner(["draft-changelog", "--version-spec", VERSION_SPEC, "--since", "foo"])
+    open_mock.assert_not_called()
+    del os.environ["RH_STEPS_TO_SKIP"]
 
 
 def test_draft_changelog_dry_run(npm_package, mocker, runner, git_prep):


### PR DESCRIPTION
Add option to "Full Release", "Draft Release", and "Publish Release" workflows to skips steps by name.
This is useful when a step is failing but you want to override anyway, like when a changelog is out of sync according to `github-activity`, but you want to include it anyway.
Will follow up with an update to the documentation to include screen shots with the new option.
