### PR TITLE
Fix Check Release and Check Links Actions

### DIFF
--- a/.github/actions/check-links/action.yml
+++ b/.github/actions/check-links/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      uses: ./.github/actions/install-releaser
+      uses: jupyter-server/jupyter_releaser/.github/actions/install-releaser@v1
 
     - name: Cache checked links
       uses: actions/cache@v2

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -12,10 +12,10 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      uses: ./.github/actions/install-releaser
+      uses: jupyter-server/jupyter_releaser/.github/actions/install-releaser@v1
 
     - name: draft-changelog
-      uses: ./.github/actions/draft-changelog
+      uses: jupyter-server/jupyter_releaser/.github/actions/draft-changelog@v1
       env:
         RH_IS_CHECK_RELEASE: "true"
       with:
@@ -24,7 +24,7 @@ runs:
         changelog: ${{ inputs.changelog }}
 
     - name: draft-release
-      uses: ./.github/actions/draft-release
+      uses: jupyter-server/jupyter_releaser/.github/actions/draft-release@v1
       env:
         RH_IS_CHECK_RELEASE: "true"
       with:
@@ -33,7 +33,7 @@ runs:
         changelog: ${{ inputs.changelog }}
 
     - name: publish-release
-      uses: ./.github/actions/publish-release
+      uses: jupyter-server/jupyter_releaser/.github/actions/publish-release@v1
       env:
         RH_IS_CHECK_RELEASE: "true"
       with:


### PR DESCRIPTION
Follow up to https://github.com/jupyter-server/jupyter_releaser/pull/182. Relative links to actions don't work when used from other repos: https://github.com/ipython/ipykernel/pull/788/checks?check_run_id=3943113875