### PR TITLE
Make all of the actions use v1 tag internally

### DIFF
--- a/.github/actions/draft-changelog/action.yml
+++ b/.github/actions/draft-changelog/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      uses: ./.github/actions/install-releaser
+      uses: jupyter-server/jupyter_releaser/.github/actions/install-releaser@v1
 
     - shell: bash
       id: draft-changelog

--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -39,7 +39,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      uses: ./.github/actions/install-releaser
+      uses: jupyter-server/jupyter_releaser/.github/actions/install-releaser@v1
 
     - shell: bash
       id: draft-release

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      uses: ./.github/actions/install-releaser
+      uses: jupyter-server/jupyter_releaser/.github/actions/install-releaser@v1
 
     - shell: bash
       id: publish-release


### PR DESCRIPTION
Follow up to https://github.com/jupyter-server/jupyter_releaser/pull/184. Since all of the actions are used by other repos, we need to use the v1 tag for all sibling action calls.