### PR TITLE
Skip branch setup on publish

### DIFF
--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -2,10 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
-from jupyter_releaser.actions.common import setup
 from jupyter_releaser.util import run
 
-setup()
 release_url = os.environ["release_url"]
 
 if release_url:

--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -9,7 +9,9 @@ default_branch = get_default_branch()
 
 if release_url:
     run(f"jupyter-releaser extract-release {release_url}")
-    run(f"jupyter-releaser forwardport-changelog {release_url} --branch {default_branch}")
+    run(
+        f"jupyter-releaser forwardport-changelog {release_url} --branch {default_branch}"
+    )
 
 run(f"jupyter-releaser publish-assets {release_url}")
 

--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -2,7 +2,8 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
-from jupyter_releaser.util import get_default_branch, run
+from jupyter_releaser.util import get_default_branch
+from jupyter_releaser.util import run
 
 release_url = os.environ["release_url"]
 default_branch = get_default_branch()

--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -2,13 +2,14 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
-from jupyter_releaser.util import run
+from jupyter_releaser.util import get_default_branch, run
 
 release_url = os.environ["release_url"]
+default_branch = get_default_branch()
 
 if release_url:
     run(f"jupyter-releaser extract-release {release_url}")
-    run(f"jupyter-releaser forwardport-changelog {release_url}")
+    run(f"jupyter-releaser forwardport-changelog {release_url} --branch {default_branch}")
 
 run(f"jupyter-releaser publish-assets {release_url}")
 


### PR DESCRIPTION
Publishing a release seems to be failing on repos with a default branch not named `master` at the `forwardport-changelog` step.

Example run for a repo with `main` as the default branch: https://github.com/jtpio/jupyter_releaser/runs/3951643392?check_suite_focus=true

Comparing this workflow:

![image](https://user-images.githubusercontent.com/591645/138165348-64cf653a-5ebe-4f7a-bc8c-d568e407cf48.png)

To a previous successful one:

![image](https://user-images.githubusercontent.com/591645/138165468-2dbd24b9-7392-452a-8f67-4e05e98d93bc.png)

We see the releaser used to run `git remote show origin` first to retrieve the default branch.

Which seems to indicate that it was defaulting to:

https://github.com/jupyter-server/jupyter_releaser/blob/6dd044a248ba4865c4a94ca9131f941bba2de6c8/jupyter_releaser/util.py#L123-L128

Here:

https://github.com/jupyter-server/jupyter_releaser/blob/6dd044a248ba4865c4a94ca9131f941bba2de6c8/jupyter_releaser/lib.py#L581

Probably the `branch` was previously not passed down to `forwardport_changelog` (empty).

This PR removes the `RH_BRANCH` override which should revert back to the previous behavior (not tested yet)