### PR TITLE
Clean up actions and workflows

### DIFF
--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: Use PRs with activity since the last stable git tag
     required: false
   steps_to_skip:
-    description: comma-separated list of steps to steps_to_skip
+    description: Comma separated list of steps to skip
     required: false
 
 outputs:

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "false"
     required: false
   steps_to_skip:
-    description: comma-separated list of steps to steps_to_skip
+    description: Comma separated list of steps to skip
     required: false
 
 outputs:

--- a/.github/workflows/draft-changelog.yml
+++ b/.github/workflows/draft-changelog.yml
@@ -18,7 +18,7 @@ on:
         description: Use PRs with activity since the last stable git tag
         required: false
 jobs:
-  changelog:
+  draft_changelog:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,10 +21,10 @@ on:
         description: Use PRs with activity since the last stable git tag
         required: false
       steps_to_skip:
-        description: comma-separated list of steps to steps_to_skip
+        description: Comma separated list of steps to skip
         required: false
 jobs:
-  release:
+  draft_release:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -21,11 +21,11 @@ on:
         description: Use PRs with activity since the last stable git tag
         required: false
       steps_to_skip:
-        description: comma-separated list of steps to steps_to_skip
+        description: Comma separated list of steps to skip
         required: false
 
 jobs:
-  release:
+  full_release:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -18,7 +18,7 @@ on:
         description: Use PRs with activity until this date or git reference
         required: false
 jobs:
-  build:
+  generate_changelog:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Check Links
         uses: ./.github/actions/check-links
 
-  build:
+  test:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Clean up the names used in the actions and workflows, and fix the descriptions used for `steps_to_skip`.