### PR TITLE
Remove default branch logic

### DIFF
--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -2,17 +2,13 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
-from jupyter_releaser.util import get_default_branch
 from jupyter_releaser.util import run
 
 release_url = os.environ["release_url"]
-default_branch = get_default_branch()
 
 if release_url:
     run(f"jupyter-releaser extract-release {release_url}")
-    run(
-        f"jupyter-releaser forwardport-changelog {release_url} --branch {default_branch}"
-    )
+    run(f"jupyter-releaser forwardport-changelog {release_url}")
 
 run(f"jupyter-releaser publish-assets {release_url}")
 


### PR DESCRIPTION
Follow-up to #192 

This logic was picking up the `master` branch of the releaser repo.

With this change we remove the explicit branch name and let the `forwardport_changelog` choose the default branch if needed.

This seems to work with the Publish Release workflow. Not sure about the Full Release.