### PR TITLE
Remove empty documentation entry

### DIFF
--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -124,8 +124,8 @@ def get_version_entry(
     entry = "\n".join(entry).strip()
 
     # Remove empty documentation entry if only automated changelogs were there
-    if '# Documentation improvements\n\n' in entry:
-        entry = re.sub(r'#+ Documentation improvements\n\n', '')
+    if "# Documentation improvements\n\n" in entry:
+        entry = re.sub(r"#+ Documentation improvements\n\n", "", entry)
 
     # Replace "*" unordered list marker with "-" since this is what
     # Prettier uses

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -123,6 +123,10 @@ def get_version_entry(
 
     entry = "\n".join(entry).strip()
 
+    # Remove empty documentation entry if only automated changelogs were there
+    if '# Documentation improvements\n\n' in entry:
+        entry = re.sub(r'#+ Documentation improvements\n\n', '')
+
     # Replace "*" unordered list marker with "-" since this is what
     # Prettier uses
     # TODO: remove after github_activity 0.1.4+ is available


### PR DESCRIPTION
If the only documentation PR(s) were automated, remove that entry from the changelog.