### PR TITLE
Fix missing quote in Draft Changelog

### DIFF
--- a/.github/workflows/draft-changelog.yml
+++ b/.github/workflows/draft-changelog.yml
@@ -6,7 +6,7 @@ on:
         description: "The owner/repo GitHub target"
         required: true
       branch:
-        description: The branch to target"
+        description: "The branch to target"
         required: true
       version_spec:
         description: "New Version Spec"


### PR DESCRIPTION
Recently caught when making a release:

![image](https://user-images.githubusercontent.com/591645/144833075-ed131a6e-f1a3-4b01-bca0-f46fadab9f15.png)
