### PR TITLE
Sort the list of workspace package versions

### DIFF
--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -149,7 +149,7 @@ def get_package_versions(version):
         message += f'\nnpm version: {data["name"]}: {npm_version}'
     if "workspaces" in data:
         message += "\nnpm workspace versions:"
-        for path in _get_workspace_packages(data):
+        for path in sorted(_get_workspace_packages(data)):
             text = path.joinpath("package.json").read_text(encoding="utf-8")
             data = json.loads(text)
             message += f'\n{data["name"]}: {data.get("version", "")}'

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -149,7 +149,7 @@ def get_package_versions(version):
         message += f'\nnpm version: {data["name"]}: {npm_version}'
     if "workspaces" in data:
         message += "\nnpm workspace versions:"
-        for path in sorted(_get_workspace_packages(data)):
+        for path in _get_workspace_packages(data):
             text = path.joinpath("package.json").read_text(encoding="utf-8")
             data = json.loads(text)
             message += f'\n{data["name"]}: {data.get("version", "")}'
@@ -199,4 +199,4 @@ def _get_workspace_packages(data):
                 continue
             paths.append(sub_package)
 
-    return paths
+    return sorted(paths)


### PR DESCRIPTION
At the moment the changelog shows a list of unordered npm packages:

For example: https://github.com/jupyterlab/jupyterlab/pull/11651

This change sorts them so it's a bit more pleasing to the eye.