### PR TITLE
Beautify rendering of the configuration file list

### DIFF
--- a/docs/source/how_to_guides/write_config.md
+++ b/docs/source/how_to_guides/write_config.md
@@ -27,11 +27,9 @@ Note: the only unusable hook names are `before-prep-git` and `before-extract-rel
 
 This is where `jupyter-releaser` looks for configuration (first one found is used):
 
-```
-    .jupyter-releaser.toml
-    pyproject.toml (in the tools.jupyter-releaser section )
-    package.json (in the jupyter-releaser property)
-```
+- `.jupyter-releaser.toml`
+- `pyproject.toml` (in the tools.jupyter-releaser section)
+- `package.json` (in the jupyter-releaser property)
 
 Example `.jupyter-releaser.toml`:
 


### PR DESCRIPTION
The syntax highlighting was kicking in on this one:

![Screenshot from 2021-12-11 00-33-03](https://user-images.githubusercontent.com/5832902/145656943-a822c56d-ba65-424f-8e20-a9bc153a53a8.png)

Now it will be rendered like a proper list.