### PR TITLE
Use the last line of the `python setup.py --version` command to get the Python version

### DIFF
--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -133,7 +133,7 @@ def get_repo():
 def get_version():
     """Get the current package version"""
     if SETUP_PY.exists():
-        return run("python setup.py --version").split("\n")[-1])
+        return run("python setup.py --version").split("\n")[-1]
     elif PACKAGE_JSON.exists():
         return json.loads(PACKAGE_JSON.read_text(encoding="utf-8")).get("version", "")
     else:  # pragma: no cover

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -133,7 +133,7 @@ def get_repo():
 def get_version():
     """Get the current package version"""
     if SETUP_PY.exists():
-        return run("python setup.py --version")
+        return run("python setup.py --version").split("\n")[-1])
     elif PACKAGE_JSON.exists():
         return json.loads(PACKAGE_JSON.read_text(encoding="utf-8")).get("version", "")
     else:  # pragma: no cover


### PR DESCRIPTION
As noticed in https://github.com/jupyterlab/jupyterlab/pull/11770, recent versions of `setuptools` have switched to the Python `logging` infrastructure to log messages. Which means the output of `python setup.py --version` might now contain other messages than just the version.

This is not an issue when using the releaser for now, as there is a pin on `setuptools` here:

https://github.com/jupyter-server/jupyter_releaser/blob/68bb70314fa0347366f79774b8870d4e4f6d419d/setup.cfg#L42

Similar to https://github.com/jupyter-server/jupyter_releaser/pull/37, this changes proposes to parse the last line of the `python setup.py --version` command only.