### PR TITLE
Update to the new `main` default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,6 @@ jobs:
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RH_REPOSITORY: jupyter-server/jupyter_releaser
-          RH_BRANCH: main
           RH_SINCE: v0.3.0
           RH_UNTIL: v0.4.0
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RH_REPOSITORY: jupyter-server/jupyter_releaser
-          RH_BRANCH: master
+          RH_BRANCH: main
           RH_SINCE: v0.3.0
           RH_UNTIL: v0.4.0
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
     branches: ["*"]
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ You can also invoke the pre-commit hook manually at any time with
 pre-commit run
 ```
 
-Once you have done this, you can launch the master branch of Jupyter Releaser
+Once you have done this, you can launch the main branch of Jupyter Releaser
 from any directory in your system with::
 
 ```bash

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
 html_context = {
     "github_user": "jupyterlab",  # Username
     "github_repo": "jupyterlab_server",  # Repo name
-    "github_version": "master",  # Version
+    "github_version": "main",  # Version
     "doc_path": "/docs/source/",  # Path in the checkout to the docs root
 }
 

--- a/docs/source/how_to_guides/convert_repo.md
+++ b/docs/source/how_to_guides/convert_repo.md
@@ -43,9 +43,9 @@ B. Prep target repository:
   - We recommend [MyST](https://myst-parser.readthedocs.io/en/latest/?badge=latest), especially if some of your docs are in reStructuredText.
   - Can use `pandoc -s changelog.rst -o changelog.md` and some hand edits as needed.
   - Note that [directives](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#syntax-directives) can still be used
-- [ ] Add HTML start and end comment markers to Changelog file - see example in [CHANGELOG.md](https://github.com/jupyter-server/jupyter_releaser/blob/master/CHANGELOG.md) (view in raw mode)
-- [ ] Add [tbump](https://github.com/tankerhq/tbump) support if using Python - see example metadata in [pyproject.toml](https://github.com/jupyter-server/jupyter_releaser/blob/master/pyproject.toml)
-  - We recommend putting `setuptools` metadata in `setup.cfg` and using `version = attr: <package_name>.__version__`, see example [`setup.cfg`](https://github.com/jupyter-server/jupyter_releaser/blob/master/setup.cfg)
+- [ ] Add HTML start and end comment markers to Changelog file - see example in [CHANGELOG.md](https://github.com/jupyter-server/jupyter_releaser/blob/main/CHANGELOG.md) (view in raw mode)
+- [ ] Add [tbump](https://github.com/tankerhq/tbump) support if using Python - see example metadata in [pyproject.toml](https://github.com/jupyter-server/jupyter_releaser/blob/main/pyproject.toml)
+  - We recommend putting `setuptools` metadata in `setup.cfg` and using `version = attr: <package_name>.__version__`, see example [`setup.cfg`](https://github.com/jupyter-server/jupyter_releaser/blob/main/setup.cfg)
   - See documentation on `setup.cfg` [metadata](https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html)
   - If previously providing `version_info` like `version_info = (1, 7, 0, '.dev', '0')`, use tbump config like the one below:
 


### PR DESCRIPTION
Looks like the default branch has been renamed to `main`, but some references still need to be updated.