### PR TITLE
Run CI on Python 3.10

### DIFF
--- a/.github/workflows/draft-changelog.yml
+++ b/.github/workflows/draft-changelog.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     env:
       VERSION_SPEC: ${{ github.event.inputs.version_spec }}
       POST_VERSION_SPEC: ${{ github.event.inputs.post_version_spec }}

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     env:
       VERSION_SPEC: ${{ github.event.inputs.version_spec }}
       POST_VERSION_SPEC: ${{ github.event.inputs.post_version_spec }}

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       # ref: https://github.com/pre-commit/action
       - uses: pre-commit/action@v2.0.0
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ["3.7", "3.9"]
+        python-version: ["3.7", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
           auto-update-conda: true
           activate-environment: jupyter_releaser_documentation
           environment-file: docs/environment.yml
-          python-version: "3.9"
+          python-version: "3.10"
           auto-activate-base: false
 
       - name: Cache conda

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: jupyter_releaser_documentation
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.10
   - sphinx
   - sphinx-copybutton
   - pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,10 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 zip_safe = False


### PR DESCRIPTION
- Switch from Python `3.9` to `3.10` when testing on CI
- Update trove classifiers