### PR TITLE
Add configurable python target to check-python

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -184,12 +184,13 @@ python_packages_options = [
     )
 ]
 
-python_target_options = [
+python_imports_options = [
     click.option(
-        "--python-target",
-        envvar="RH_PYTHON_TARGET",
-        default="",
-        help="The Python package import to check for; default to the Python package name.",
+        "--check-imports",
+        envvar="RH_CHECK_IMPORTS",
+        default=[],
+        multiple=True,
+        help="The Python packages import to check for; default to the Python package name.",
     )
 ]
 
@@ -412,16 +413,16 @@ def build_python(dist_dir, python_packages):
 
 @main.command()
 @add_options(dist_dir_options)
-@add_options(python_target_options)
+@add_options(python_imports_options)
 @use_checkout_dir()
-def check_python(dist_dir, python_target):
+def check_python(dist_dir, python_imports):
     """Check Python dist files"""
     for dist_file in glob(f"{dist_dir}/*"):
         if Path(dist_file).suffix not in [".gz", ".whl"]:
             util.log(f"Skipping non-python dist file {dist_file}")
             continue
-        test_cmd = f'python -c "import {python_target}"' if python_target else ""
-        python.check_dist(dist_file, test_cmd)
+
+        python.check_dist(dist_file, python_imports=python_imports)
 
 
 @main.command()

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -184,6 +184,15 @@ python_packages_options = [
     )
 ]
 
+python_target_options = [
+    click.option(
+        "--python-target",
+        envvar="RH_PYTHON_TARGET",
+        default="",
+        help="The Python package import to check for; default to the Python package name."
+    )
+]
+
 dry_run_options = [
     click.option(
         "--dry-run", is_flag=True, envvar="RH_DRY_RUN", help="Run as a dry run"
@@ -403,14 +412,16 @@ def build_python(dist_dir, python_packages):
 
 @main.command()
 @add_options(dist_dir_options)
+@add_options(python_target_options)
 @use_checkout_dir()
-def check_python(dist_dir):
+def check_python(dist_dir, python_target):
     """Check Python dist files"""
     for dist_file in glob(f"{dist_dir}/*"):
         if Path(dist_file).suffix not in [".gz", ".whl"]:
             util.log(f"Skipping non-python dist file {dist_file}")
             continue
-        python.check_dist(dist_file)
+        test_cmd = f'python -c "import {python_target}"' if python_target else ""
+        python.check_dist(dist_file, test_cmd)
 
 
 @main.command()

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -184,7 +184,7 @@ python_packages_options = [
     )
 ]
 
-python_imports_options = [
+check_imports_options = [
     click.option(
         "--check-imports",
         envvar="RH_CHECK_IMPORTS",
@@ -413,16 +413,16 @@ def build_python(dist_dir, python_packages):
 
 @main.command()
 @add_options(dist_dir_options)
-@add_options(python_imports_options)
+@add_options(check_imports_options)
 @use_checkout_dir()
-def check_python(dist_dir, python_imports):
+def check_python(dist_dir, check_imports):
     """Check Python dist files"""
     for dist_file in glob(f"{dist_dir}/*"):
         if Path(dist_file).suffix not in [".gz", ".whl"]:
             util.log(f"Skipping non-python dist file {dist_file}")
             continue
 
-        python.check_dist(dist_file, python_imports=python_imports)
+        python.check_dist(dist_file, python_imports=check_imports)
 
 
 @main.command()

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -189,7 +189,7 @@ python_target_options = [
         "--python-target",
         envvar="RH_PYTHON_TARGET",
         default="",
-        help="The Python package import to check for; default to the Python package name."
+        help="The Python package import to check for; default to the Python package name.",
     )
 ]
 

--- a/jupyter_releaser/python.py
+++ b/jupyter_releaser/python.py
@@ -7,7 +7,7 @@ import re
 import shlex
 from glob import glob
 from pathlib import Path
-from subprocess import PIPE
+from subprocess import PIPE, CalledProcessError
 from subprocess import Popen
 from tempfile import TemporaryDirectory
 
@@ -58,7 +58,12 @@ def check_dist(dist_file, test_cmd=""):
         util.run(f"python -m venv {env_path}")
         util.run(f"{bin_path}/python -m pip install -q -U pip")
         util.run(f"{bin_path}/pip install -q {dist_file}")
-        util.run(f"{bin_path}/{test_cmd}")
+        try:
+            util.run(f"{bin_path}/{test_cmd}")
+        except CalledProcessError as e:
+            if test_cmd == "":
+                util.log('You may need to set "python_target" to an appropriate Python package name in the config file.')
+            raise e
 
 
 def get_pypi_token(release_url, python_package):

--- a/jupyter_releaser/python.py
+++ b/jupyter_releaser/python.py
@@ -7,7 +7,8 @@ import re
 import shlex
 from glob import glob
 from pathlib import Path
-from subprocess import PIPE, CalledProcessError
+from subprocess import CalledProcessError
+from subprocess import PIPE
 from subprocess import Popen
 from tempfile import TemporaryDirectory
 
@@ -62,7 +63,9 @@ def check_dist(dist_file, test_cmd=""):
             util.run(f"{bin_path}/{test_cmd}")
         except CalledProcessError as e:
             if test_cmd == "":
-                util.log('You may need to set "python_target" to an appropriate Python package name in the config file.')
+                util.log(
+                    'You may need to set "python_target" to an appropriate Python package name in the config file.'
+                )
             raise e
 
 

--- a/jupyter_releaser/tests/conftest.py
+++ b/jupyter_releaser/tests/conftest.py
@@ -81,6 +81,11 @@ def py_multipackage(git_repo):
 
 
 @fixture
+def py_package_different_names(git_repo):
+    return testutil.create_python_package(git_repo, not_matching_name=True)
+
+
+@fixture
 def npm_package(git_repo):
     return testutil.create_npm_package(git_repo)
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -163,6 +163,7 @@ output: RH_CHANGELOG_OUTPUT
 post-version-message: RH_POST_VERSION_MESSAGE
 post-version-spec: RH_POST_VERSION_SPEC
 python-packages: RH_PYTHON_PACKAGES
+python-target: RH_PYTHON_TARGET
 ref: RH_REF
 release-message: RH_RELEASE_MESSAGE
 repo: RH_REPOSITORY

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -435,6 +435,16 @@ def test_check_python(py_package, runner, build_mock, git_prep):
     assert "after-check-python" in log
 
 
+def test_check_python_different_names(monkeypatch, py_package_different_names, runner, build_mock, git_prep):
+    monkeypatch.setenv("RH_PYTHON_TARGET", "foobar")
+    runner(["build-python"])
+    runner(["check-python"])
+
+    log = get_log()
+    assert "before-check-python" in log
+    assert "after-check-python" in log
+
+
 def test_handle_npm(npm_package, runner, git_prep):
     runner(["build-npm"])
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -152,6 +152,7 @@ auth: GITHUB_ACCESS_TOKEN
 branch: RH_BRANCH
 cache-file: RH_CACHE_FILE
 changelog-path: RH_CHANGELOG
+check-imports: RH_CHECK_IMPORTS
 dist-dir: RH_DIST_DIR
 dry-run: RH_DRY_RUN
 links-expire: RH_LINKS_EXPIRE
@@ -163,7 +164,6 @@ output: RH_CHANGELOG_OUTPUT
 post-version-message: RH_POST_VERSION_MESSAGE
 post-version-spec: RH_POST_VERSION_SPEC
 python-packages: RH_PYTHON_PACKAGES
-check-imports: RH_CHECK_IMPORTS
 ref: RH_REF
 release-message: RH_RELEASE_MESSAGE
 repo: RH_REPOSITORY

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -163,7 +163,7 @@ output: RH_CHANGELOG_OUTPUT
 post-version-message: RH_POST_VERSION_MESSAGE
 post-version-spec: RH_POST_VERSION_SPEC
 python-packages: RH_PYTHON_PACKAGES
-python-target: RH_PYTHON_TARGET
+check-imports: RH_CHECK_IMPORTS
 ref: RH_REF
 release-message: RH_RELEASE_MESSAGE
 repo: RH_REPOSITORY
@@ -439,7 +439,7 @@ def test_check_python(py_package, runner, build_mock, git_prep):
 def test_check_python_different_names(
     monkeypatch, py_package_different_names, runner, build_mock, git_prep
 ):
-    monkeypatch.setenv("RH_PYTHON_TARGET", "foobar")
+    monkeypatch.setenv("RH_CHECK_IMPORTS", "foobar")
     runner(["build-python"])
     runner(["check-python"])
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -435,7 +435,9 @@ def test_check_python(py_package, runner, build_mock, git_prep):
     assert "after-check-python" in log
 
 
-def test_check_python_different_names(monkeypatch, py_package_different_names, runner, build_mock, git_prep):
+def test_check_python_different_names(
+    monkeypatch, py_package_different_names, runner, build_mock, git_prep
+):
     monkeypatch.setenv("RH_PYTHON_TARGET", "foobar")
     runner(["build-python"])
     runner(["check-python"])

--- a/jupyter_releaser/tests/util.py
+++ b/jupyter_releaser/tests/util.py
@@ -46,11 +46,11 @@ CHANGELOG_ENTRY = f"""
 """
 
 
-def setup_cfg_template(package_name="foo"):
+def setup_cfg_template(package_name="foo", module_name=None):
     return f"""
 [metadata]
 name = {package_name}
-version = attr: {package_name}.__version__
+version = attr: {module_name or package_name}.__version__
 description = My package description
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -62,7 +62,7 @@ url = https://foo.com
 [options]
 zip_safe = False
 include_package_data = True
-py_modules = {package_name}
+py_modules = {module_name or package_name}
 """
 
 
@@ -171,13 +171,16 @@ def get_log():
     return log.read_text(encoding="utf-8").splitlines()
 
 
-def create_python_package(git_repo, multi=False):
-    def write_files(git_repo, sub_packages=[], package_name="foo"):
+def create_python_package(git_repo, multi=False, not_matching_name=False):
+    def write_files(git_repo, sub_packages=[], package_name="foo", module_name=None):
+
+        module_name = module_name or package_name
+
         setuppy = git_repo / "setup.py"
         setuppy.write_text(SETUP_PY_TEMPLATE, encoding="utf-8")
 
         setuppy = git_repo / "setup.cfg"
-        setuppy.write_text(setup_cfg_template(package_name), encoding="utf-8")
+        setuppy.write_text(setup_cfg_template(package_name, module_name), encoding="utf-8")
 
         tbump = git_repo / "tbump.toml"
         tbump.write_text(
@@ -188,7 +191,7 @@ def create_python_package(git_repo, multi=False):
         pyproject = git_repo / "pyproject.toml"
         pyproject.write_text(pyproject_template(sub_packages), encoding="utf-8")
 
-        foopy = git_repo / f"{package_name}.py"
+        foopy = git_repo / f"{module_name}.py"
         foopy.write_text(PY_MODULE_TEMPLATE, encoding="utf-8")
 
         manifest = git_repo / "MANIFEST.in"
@@ -215,11 +218,24 @@ def create_python_package(git_repo, multi=False):
                 }
             )
             sub_package.mkdir()
-            write_files(git_repo / sub_package, package_name=f"foo{i}")
+            package_name = f"foo{i}"
+            module_name = f"foo{i}bar" if not_matching_name else None
+            write_files(
+                git_repo / sub_package,
+                package_name=package_name,
+                module_name=module_name
+            )
             run(f"git add {sub_package}")
             run(f'git commit -m "initial python {sub_package}"')
 
-    write_files(git_repo, sub_packages=sub_packages)
+    package_name = "foo"
+    module_name = "foobar" if not_matching_name else None
+    write_files(
+        git_repo,
+        sub_packages=sub_packages,
+        package_name=package_name,
+        module_name=module_name
+    )
     run("git add .")
     run('git commit -m "initial python package"')
 

--- a/jupyter_releaser/tests/util.py
+++ b/jupyter_releaser/tests/util.py
@@ -180,7 +180,9 @@ def create_python_package(git_repo, multi=False, not_matching_name=False):
         setuppy.write_text(SETUP_PY_TEMPLATE, encoding="utf-8")
 
         setuppy = git_repo / "setup.cfg"
-        setuppy.write_text(setup_cfg_template(package_name, module_name), encoding="utf-8")
+        setuppy.write_text(
+            setup_cfg_template(package_name, module_name), encoding="utf-8"
+        )
 
         tbump = git_repo / "tbump.toml"
         tbump.write_text(
@@ -223,7 +225,7 @@ def create_python_package(git_repo, multi=False, not_matching_name=False):
             write_files(
                 git_repo / sub_package,
                 package_name=package_name,
-                module_name=module_name
+                module_name=module_name,
             )
             run(f"git add {sub_package}")
             run(f'git commit -m "initial python {sub_package}"')
@@ -234,7 +236,7 @@ def create_python_package(git_repo, multi=False, not_matching_name=False):
         git_repo,
         sub_packages=sub_packages,
         package_name=package_name,
-        module_name=module_name
+        module_name=module_name,
     )
     run("git add .")
     run('git commit -m "initial python package"')


### PR DESCRIPTION
Fixes #237 by allowing to define a Python target to be checked through `python -c "import <target>"` instead of using the package name.

This can be done through a new cli option `--check-imports` or the env variable `RH_CHECK_IMPORTS`.