### PR TITLE
Automated Changelog Entry for 0.11.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.11.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...318577cc3d4a7d97717b87c35141e26140ddf236))
+
+### Enhancements made
+
+- Add configurable python target to check-python [#238](https://github.com/jupyter-server/jupyter_releaser/pull/238) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Skip doctests when checking links [#239](https://github.com/jupyter-server/jupyter_releaser/pull/239) ([@blink1073](https://github.com/blink1073))
+- Add configurable python target to check-python [#238](https://github.com/jupyter-server/jupyter_releaser/pull/238) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Update generate-changelog test [#236](https://github.com/jupyter-server/jupyter_releaser/pull/236) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2022-01-02&to=2022-01-13&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2022-01-02..2022-01-13&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Acodecov-commenter+updated%3A2022-01-02..2022-01-13&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Afcollonval+updated%3A2022-01-02..2022-01-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.10.2
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...233f676c93ffddcbef3f651cb9e8a49f4254c25d))
@@ -15,8 +40,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2021-12-14&to=2021-12-15&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2021-12-14..2021-12-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.10.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.11.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | main  |
| Version Spec | 0.11.0 |
| Since | v1 |