### PR TITLE
Fix handling of doctest skip

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -53,7 +53,7 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
     cmd += "--disable-warnings --quiet "
     cmd += f"--check-links-cache-name {cache_dir}/check-release-links "
     # do not run doctests, since they might depend on other state.
-    cmd += "--doctest-glob=*.skip"
+    cmd += "-p no:doctest "
 
     ignored = []
     for spec in ignore_glob:


### PR DESCRIPTION
It turns out if you invoke an RST file directly you can't skip the doctests even with the doctest glob option, this is a [workaround](https://github.com/pytest-dev/pytest/issues/4954#issuecomment-478055434)