### PR TITLE
Test empty changelog

### DIFF
--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -105,12 +105,11 @@ def get_version_entry(
         return f"## {version}\n\nNo merged PRs"
 
     entry = md.replace("[full changelog]", "[Full Changelog]")
-    
+
     if until:
         entry = entry.replace("...None", f"...{until}")
     else:
-        entry = entry.replace("...None", f"")
-    
+        entry = entry.replace("...None", "")
 
     entry = entry.splitlines()[2:]
 

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -105,7 +105,12 @@ def get_version_entry(
         return f"## {version}\n\nNo merged PRs"
 
     entry = md.replace("[full changelog]", "[Full Changelog]")
-    entry = entry.replace("...None", f"...{until}")
+    
+    if until:
+        entry = entry.replace("...None", f"...{until}")
+    else:
+        entry = entry.replace("...None", f"")
+    
 
     entry = entry.splitlines()[2:]
 

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -124,15 +124,14 @@ def test_get_changelog_version_entry_since_last_stable(py_package, mocker):
     assert f"## {version}" in resp
     assert testutil.PR_ENTRY in resp
 
+
 def test_get_empty_changelog(py_package, mocker):
     mocked_gen = mocker.patch("jupyter_releaser.changelog.generate_activity_md")
     mocked_gen.return_value = testutil.EMPTY_CHANGELOG_ENTRY
     branch = "foo"
     util.run("git branch baz/bar")
     ref = "heads/baz/bar"
-    resp = changelog.get_version_entry(
-        ref, branch, "baz/bar", "0.2.5", since="v0.2.4"
-    )
+    resp = changelog.get_version_entry(ref, branch, "baz/bar", "0.2.5", since="v0.2.4")
     mocked_gen.assert_called_with(
         "baz/bar",
         since="v0.2.4",

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -124,6 +124,27 @@ def test_get_changelog_version_entry_since_last_stable(py_package, mocker):
     assert f"## {version}" in resp
     assert testutil.PR_ENTRY in resp
 
+def test_get_empty_changelog(py_package, mocker):
+    mocked_gen = mocker.patch("jupyter_releaser.changelog.generate_activity_md")
+    mocked_gen.return_value = testutil.EMPTY_CHANGELOG_ENTRY
+    branch = "foo"
+    util.run("git branch baz/bar")
+    ref = "heads/baz/bar"
+    resp = changelog.get_version_entry(
+        ref, branch, "baz/bar", "0.2.5", since="v0.2.4"
+    )
+    mocked_gen.assert_called_with(
+        "baz/bar",
+        since="v0.2.4",
+        until=None,
+        kind="pr",
+        branch=branch,
+        heading_level=2,
+        auth=None,
+    )
+
+    assert not ("...None" in resp)
+
 
 def test_compute_sha256(py_package):
     assert len(util.compute_sha256(py_package / "CHANGELOG.md")) == 64

--- a/jupyter_releaser/tests/util.py
+++ b/jupyter_releaser/tests/util.py
@@ -45,6 +45,16 @@ CHANGELOG_ENTRY = f"""
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)
 """
 
+EMPTY_CHANGELOG_ENTRY = f"""
+## main@{{2021-09-15}}...main@{{2022-01-18}}
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.4...None))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-09-15&to=2022-01-18&type=c))
+
+"""
 
 def setup_cfg_template(package_name="foo", module_name=None):
     return f"""

--- a/jupyter_releaser/tests/util.py
+++ b/jupyter_releaser/tests/util.py
@@ -45,8 +45,8 @@ CHANGELOG_ENTRY = f"""
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)
 """
 
-EMPTY_CHANGELOG_ENTRY = f"""
-## main@{{2021-09-15}}...main@{{2022-01-18}}
+EMPTY_CHANGELOG_ENTRY = """
+## main@{2021-09-15}...main@{2022-01-18}
 
 ([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.4...None))
 
@@ -55,6 +55,7 @@ EMPTY_CHANGELOG_ENTRY = f"""
 ([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-09-15&to=2022-01-18&type=c))
 
 """
+
 
 def setup_cfg_template(package_name="foo", module_name=None):
     return f"""


### PR DESCRIPTION
solves #131 

I'm trying to remove the `...None` from the diff when the changelog is empty. I'm not sure if this is the right solution. I'm a bit lost on how the release works. Meanwhile, I added a test to check if the changelog is empty.