### PR TITLE
ignore package pytest config

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -54,6 +54,9 @@ def check_links(ignore_glob, ignore_links, cache_file, links_expire):
     cmd += f"--check-links-cache-name {cache_dir}/check-release-links "
     # do not run doctests, since they might depend on other state.
     cmd += "-p no:doctest "
+    # ignore package pytest configuration,
+    # since we aren't running their tests
+    cmd += "-c _IGNORE_CONFIG"
 
     ignored = []
     for spec in ignore_glob:


### PR DESCRIPTION
Ignore pytest config from pyproject.toml, etc.to  avoid conflicts with target package's own pytest config, since we aren't running the package's own tests.

For example, jupyter-server has `addopts = --doctest-modules`, but check-links [now has](https://github.com/jupyter-server/jupyter_releaser/pull/241) `-p no:doctest`, which removes the `--doctest-modules` option, causing `check-links` to [fail](https://github.com/jupyter-server/jupyter_server/runs/4857720531?check_suite_focus=true#step:6:116) on jupyter-server with:

```
pytest: error: unrecognized arguments: --doctest-modules
```