### PR TITLE
Add support for minor release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-20.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash -l {0}

--- a/docs/source/get_started/making_first_release.md
+++ b/docs/source/get_started/making_first_release.md
@@ -42,7 +42,8 @@ already uses Jupyter Releaser.
   ![Draft Changelog Workflow Dialog](../images/draft_changelog.png)
 
   - The "New Version Spec" will usually be the full version (e.g. 0.7.1). Repos using `tbump` can also use the "next"
-    option, which will bump the micro version (or the build version in the case of a prerelease).
+    option, which will bump the micro version (or the build version in the case of a prerelease). The "minor" option allows projects using "tbump" to bump
+    to the next minor version directly.
   - Use the "since" field to select PRs prior to the latest tag to include in the release
   - Type "true" in the "since the last stable git tag" if you would like to include PRs since the last non-prerelease version tagged on the target repository and branch.
   - The workflow will use the GitHub API to find the relevant pull requests and make an appropriate changelog entry.

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -205,7 +205,9 @@ def test_bump_version(py_package):
     assert util.get_version() == "1.0.3a6"
     util.bump_version("1.0.3.dev1")
     util.bump_version("next")
-    assert util.get_version() == "1.0.3.dev2"
+    assert util.get_version() == "1.0.3"
+    util.bump_version("minor")
+    assert util.get_version() == "1.1.0"
 
 
 def test_get_config_python(py_package):

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -220,13 +220,15 @@ def bump_version(version_spec, version_cmd=""):
         v = parse_version(get_version())
         if version_spec == "next":
             if v.is_devrelease:
-                version_spec = f"{v.major}.{v.minor}.{v.micro}.dev{v.dev + 1}"
+                version_spec = f"{v.major}.{v.minor}.{v.micro}"
             elif v.is_prerelease:
                 version_spec = f"{v.major}.{v.minor}.{v.micro}{v.pre[0]}{v.pre[1] + 1}"
             else:
                 version_spec = f"{v.major}.{v.minor}.{v.micro + 1}"
         elif version_spec == "patch":
             version_spec = f"{v.major}.{v.minor}.{v.micro + 1}"
+        elif version_spec == "minor":
+            version_spec = f"{v.major}.{v.minor + 1}.0"
 
     # Bump the version
     run(f"{version_cmd} {version_spec}")


### PR DESCRIPTION
Fixes #244.  Also changes the way `.dev` versions are handled by "next" - we drop the `.dev` suffix and release a final version.   This had bitten us recently in `jupyter_server`.