### PR TITLE
Create forwardport PR after publishing

### DIFF
--- a/jupyter_releaser/actions/publish_release.py
+++ b/jupyter_releaser/actions/publish_release.py
@@ -8,9 +8,9 @@ release_url = os.environ["release_url"]
 
 if release_url:
     run(f"jupyter-releaser extract-release {release_url}")
-    run(f"jupyter-releaser forwardport-changelog {release_url}")
 
 run(f"jupyter-releaser publish-assets {release_url}")
 
 if release_url:
     run(f"jupyter-releaser publish-release {release_url}")
+    run(f"jupyter-releaser forwardport-changelog {release_url}")


### PR DESCRIPTION
Wait until assets have been published to create the forwardport PR.  This avoids creating multiple PRs if you have to re-run the Publish step due to a credentials error.  cf https://github.com/jupyterlab/jupyterlab/pull/12189#issuecomment-1063532768