### PR TITLE
forward python imports for checking with extract_release

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -600,13 +600,26 @@ def delete_release(auth, release_url):
 @add_options(dry_run_options)
 @add_options(npm_install_options)
 @add_options(pydist_check_options)
+@add_options(check_imports_options)
 @click.argument("release-url", nargs=1)
 def extract_release(
-    auth, dist_dir, dry_run, release_url, npm_install_options, pydist_check_cmd
+    auth,
+    dist_dir,
+    dry_run,
+    release_url,
+    npm_install_options,
+    pydist_check_cmd,
+    check_imports,
 ):
     """Download and verify assets from a draft GitHub release"""
     lib.extract_release(
-        auth, dist_dir, dry_run, release_url, npm_install_options, pydist_check_cmd
+        auth,
+        dist_dir,
+        dry_run,
+        release_url,
+        npm_install_options,
+        pydist_check_cmd,
+        check_imports,
     )
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -292,7 +292,13 @@ def delete_release(auth, release_url):
 
 
 def extract_release(
-    auth, dist_dir, dry_run, release_url, npm_install_options, pydist_check_cmd
+    auth,
+    dist_dir,
+    dry_run,
+    release_url,
+    npm_install_options,
+    pydist_check_cmd,
+    python_imports,
 ):
     """Download and verify assets from a draft GitHub release"""
     match = parse_release_url(release_url)
@@ -338,7 +344,11 @@ def extract_release(
     for asset in assets:
         suffix = Path(asset.name).suffix
         if suffix in [".gz", ".whl"]:
-            python.check_dist(dist / asset.name, check_cmd=pydist_check_cmd)
+            python.check_dist(
+                dist / asset.name,
+                check_cmd=pydist_check_cmd,
+                python_imports=python_imports,
+            )
         elif suffix == ".tgz":
             pass  # already handled
         else:


### PR DESCRIPTION
For the quetz-server we need to override the import name with `quetz` (instead of `quetz_server`).

It was otherwise impossible to release.