### PR TITLE
Fix listing of tags

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -361,9 +361,10 @@ def extract_release(
     tag_name = release.tag_name
 
     sha = None
-    for tag in gh.list_tags():
+    for tag in gh.list_tags(tag_name):
         if tag.ref == f"refs/tags/{tag_name}":
             sha = tag.object.sha
+            break
     if sha is None:
         raise ValueError("Could not find tag")
 


### PR DESCRIPTION
This should fix https://github.com/jupyter-server/jupyter_releaser/issues/278

While investigating the issue that happened during the JupyterLab 4.0.0a23 release: https://github.com/jupyterlab/jupyterlab/issues/12324

It appears the call to `gh.list_tags()` returns a 502 from GitHub.

As posted in https://github.com/jupyterlab/jupyterlab/issues/12324#issuecomment-1085533714, this is reproducible with the following code snippet:

```py
import os

from ghapi.core import GhApi

owner = 'jupyterlab'
repo = 'jupyterlab'
auth = os.getenv('GITHUB_ACCESS_TOKEN')

gh = GhApi(owner=owner, repo=repo, token=auth)

print(gh.list_tags())
```

This is probably happening because the jupyterlab repo has *a lot* of tags (28000+ at the time of writing).

This PR proposes only look for the release tag when listing all tags, which seems to be enough for the hash comparison logic below.