### PR TITLE
Improve handling of dev versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Detailed workflows are available to draft a changelog, draft a release, publish 
 - Checks the links in Markdown and reStructuredText files
 - Adds a commit that includes the hashes of the dist files
 - Creates an annotated version tag in standard format
-- If given, bumps the version using the post version spec
+- If given, bumps the version using the post version spec. The post version
+  spec can also be given as a setting, see the [Write Releaser Config Guide](https://jupyter-releaser.readthedocs.io/en/latest/how_to_guides/write_config.html).
 - Pushes the commits and tag to the target `branch`
 - Publishes a draft GitHub release for the tag with the changelog entry as the text
 

--- a/docs/source/background/theory.md
+++ b/docs/source/background/theory.md
@@ -57,7 +57,8 @@ Detailed workflows are available to draft a changelog, draft a release, publish 
 - Checks the links in Markdown and reStructuredText files
 - Adds a commit that includes the hashes of the dist files
 - Creates an annotated version tag in standard format
-- If given, bumps the version using the post version spec
+- If given, bumps the version using the post version spec. he post version
+  spec can also be given as a setting, [Write Releaser Config Guide](../how_to_guides/write_config.html#automatic-dev-versions).
 - Pushes the commits and tag to the target `branch`
 - Publishes a draft GitHub release for the tag with the changelog entry as the text
 

--- a/docs/source/how_to_guides/write_config.md
+++ b/docs/source/how_to_guides/write_config.md
@@ -72,3 +72,15 @@ Example `package.json`:
   }
 }
 ```
+
+## Automatic Dev Versions
+
+If you'd like to use dev versions for your repository between builds,
+use `dev` as the `post-version-spec` setting, e.g.
+
+```toml
+[tools.jupyter-releaser.options]
+post-version-spec = "dev"
+```
+
+This will bump it to the next minor release with a `.dev0` suffix.

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -299,3 +299,12 @@ def extract_current(changelog_path):
         if start != -1 and end != -1:
             body = changelog[start + len(START_MARKER) : end]
     return body
+
+
+def extract_current_version(changelog_path):
+    """Extract the current released version from the changelog"""
+    body = extract_current(changelog_path)
+    match = re.match(r"#+ ([\d.]+)", body.strip())
+    if not match:
+        raise ValueError("Could not find previous version")
+    return match.groups()[0]

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -305,14 +305,15 @@ def prep_git(ref, branch, repo, auth, username, git_url):
 @main.command()
 @add_options(version_spec_options)
 @add_options(version_cmd_options)
+@add_options(changelog_path_options)
 @add_options(python_packages_options)
 @use_checkout_dir()
-def bump_version(version_spec, version_cmd, python_packages):
+def bump_version(version_spec, version_cmd, changelog_path, python_packages):
     """Prep git and env variables and bump version"""
     prev_dir = os.getcwd()
     for python_package in [p.split(":")[0] for p in python_packages]:
         os.chdir(python_package)
-        lib.bump_version(version_spec, version_cmd)
+        lib.bump_version(version_spec, version_cmd, changelog_path)
         os.chdir(prev_dir)
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -23,9 +23,11 @@ from jupyter_releaser import python
 from jupyter_releaser import util
 
 
-def bump_version(version_spec, version_cmd):
+def bump_version(version_spec, version_cmd, changelog_path):
     """Bump the version and verify new version"""
-    util.bump_version(version_spec, version_cmd=version_cmd)
+    util.bump_version(
+        version_spec, version_cmd=version_cmd, changelog_path=changelog_path
+    )
 
     version = util.get_version()
 
@@ -237,7 +239,11 @@ def draft_release(
 
     # Bump to post version if given
     if post_version_spec:
-        post_version = bump_version(post_version_spec, version_cmd)
+        # TODO: can this be a static setting and still preserve what
+        # we have?
+        post_version = bump_version(
+            post_version_spec, version_cmd=version_cmd, changelog_path=changelog_path
+        )
         util.log(post_version_message.format(post_version=post_version))
         util.run(f'git commit -a -m "Bump to {post_version}"')
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -239,8 +239,6 @@ def draft_release(
 
     # Bump to post version if given
     if post_version_spec:
-        # TODO: can this be a static setting and still preserve what
-        # we have?
         post_version = bump_version(
             post_version_spec, version_cmd=version_cmd, changelog_path=changelog_path
         )

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -245,8 +245,8 @@ def test_handle_npm_config(npm_package):
         npmrc.write_text(npmrc_text, encoding="utf-8")
 
 
-def test_bump_version(py_package):
-    for spec in ["1.0.1", "1.0.1.dev1", "1.0.3a4"]:
+def test_bump_version_reg(py_package):
+    for spec in ["1.0.1", "1.0.3a4"]:
         util.bump_version(spec)
         util.run("git commit -a -m 'bump version'")
         assert util.get_version() == spec
@@ -258,11 +258,25 @@ def test_bump_version(py_package):
     util.bump_version("1.0.3a5")
     util.bump_version("next")
     assert util.get_version() == "1.0.3a6"
-    util.bump_version("1.0.3.dev1")
-    util.bump_version("next")
-    assert util.get_version() == "1.0.3"
     util.bump_version("minor")
     assert util.get_version() == "1.1.0"
+
+
+def test_bump_version_dev(py_package):
+    util.bump_version("dev")
+    assert util.get_version() == "0.1.0.dev0"
+    util.bump_version("dev")
+    assert util.get_version() == "0.1.0.dev1"
+    # Should get the version from the changelog
+    util.bump_version("next", changelog_path=py_package / "CHANGELOG.md")
+    assert util.get_version() == "0.0.2"
+    util.bump_version("dev")
+    assert util.get_version() == "0.1.0.dev0"
+    util.bump_version("patch", changelog_path=py_package / "CHANGELOG.md")
+    assert util.get_version() == "0.0.2"
+    util.bump_version("1.0.0.dev0")
+    util.bump_version("minor")
+    assert util.get_version() == "1.0.0"
 
 
 def test_get_config_python(py_package):


### PR DESCRIPTION
Working toward #272.  Allows a simplified handling of dev mode, using the following config:

```toml
[tools.jupyter-releaser.options]
post-version-spec = "dev"
```