### PR TITLE
Automated Changelog Entry for 0.18.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.18.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...1b5a66584078f85fa0e72c6c111563bd5cde7b0b))
+
+### Enhancements made
+
+- Handle manual backport PRs [#303](https://github.com/jupyter-server/jupyter_releaser/pull/303) ([@blink1073](https://github.com/blink1073))
+- Add a utility to get the latest draft release for a given repo [#301](https://github.com/jupyter-server/jupyter_releaser/pull/301) ([@blink1073](https://github.com/blink1073))
+- Add ability to parse github release changelog [#298](https://github.com/jupyter-server/jupyter_releaser/pull/298) ([@blink1073](https://github.com/blink1073))
+
+### Bugs fixed
+
+- Only run check-manifest if using setuptools [#302](https://github.com/jupyter-server/jupyter_releaser/pull/302) ([@blink1073](https://github.com/blink1073))
+
+### Maintenance and upkeep improvements
+
+- Clean up pytest and add mypy handling [#300](https://github.com/jupyter-server/jupyter_releaser/pull/300) ([@blink1073](https://github.com/blink1073))
+- [pre-commit.ci] pre-commit autoupdate [#299](https://github.com/jupyter-server/jupyter_releaser/pull/299) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+- Clean up pre-commit [#295](https://github.com/jupyter-server/jupyter_releaser/pull/295) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2022-04-07&to=2022-04-18&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2022-04-07..2022-04-18&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Acodecov-commenter+updated%3A2022-04-07..2022-04-18&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Apre-commit-ci+updated%3A2022-04-07..2022-04-18&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.17.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_releaser/compare/v1...749241d219b73e22eea1702dfb7e615b897abc3e))
@@ -19,8 +47,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_releaser/graphs/contributors?from=2022-04-06&to=2022-04-07&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_releaser+involves%3Ablink1073+updated%3A2022-04-06..2022-04-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.16.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.18.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_releaser  |
| Branch  | main  |
| Version Spec | minor |
| Since | v1 |