### PR TITLE
Add hatchling handling

### DIFF
--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -38,6 +38,16 @@ def test_get_version_pyproject_dynamic(py_package):
     assert util.get_version() == "0.0.1"
 
 
+def test_get_version_hatchling(py_package):
+    py_project = py_package / "pyproject.toml"
+    with open(py_project) as fid:
+        data = toml.load(fid)
+    del data["project"]["version"]
+    data["build-system"] = {"requires": ["hatchling>=1.0"], "build-backend": "hatchling.build"}
+    with open(py_project, "w") as fid:
+        fid.write(str(py_project))
+
+
 def test_get_version_setuppy(py_package):
     assert util.get_version() == "0.0.1"
     util.bump_version("0.0.2a0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "click",
     "ghapi",
     "github-activity~=0.2",
+    "hatchling>=1.0",
     "importlib_resources",
     "jsonschema>=3.0.1",
     "packaging",


### PR DESCRIPTION
Fixes issue seen in https://github.com/jupyter/notebook/pull/6448 where `releaser` tries to use `python setup.py --version` to get the file, when it should be using `hatchling.version`.