### PR TITLE
Fix a bug when retrieving package version

### DIFF
--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -180,6 +180,7 @@ def get_version():
             wheel_path = glob(f"{tempdir}/*.whl")[0]
             wheel = Wheel(wheel_path)
             version = wheel.version
+            return version
 
     if PACKAGE_JSON.exists():
         return json.loads(PACKAGE_JSON.read_text(encoding="utf-8")).get("version", "")


### PR DESCRIPTION
This PR add a return value when getting version by building wheel, which is missing in the latest version of jupyter_releaser.