### PR TITLE
Revert changes to handle dev versions

### DIFF
--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -58,8 +58,6 @@ runs:
         export RH_SINCE=${{ inputs.since }}
         export RH_SINCE_LAST_STABLE=${{ inputs.since_last_stable }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
-        export RH_USE_CHANGELOG_VERSION=1
-        export RH_VERSION_CREATE_TAG=1
 
         # Draft Release
         python -m jupyter_releaser.actions.draft_release

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -22,4 +22,5 @@ jobs:
       - name: Check Release
         uses: ./.github/actions/check-release
         with:
+          version_spec: 10.10.10
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = "2021, Project Jupyter"
 author = "Project Jupyter"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.23.0.dev0"
+release = "0.22.3"
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
 

--- a/docs/source/get_started/making_first_release.md
+++ b/docs/source/get_started/making_first_release.md
@@ -41,9 +41,11 @@ already uses Jupyter Releaser.
 
   ![Draft Changelog Workflow Dialog](../images/draft_changelog.png)
 
-  - The "New Version Spec" will usually be the full version (e.g. 0.7.1). Repos using `tbump` can also use the "next"
+  - The "New Version Spec" will usually be the full version (e.g. 0.7.1). Repos using `tbump` can also use the "next" or "patch"
     option, which will bump the micro version (or the build version in the case of a prerelease). The "minor" option allows projects using "tbump" to bump
-    to the next minor version directly.
+    to the next minor version directly. Note: The "next" and "patch" options
+    are not available when using dev versions, you must use explicit versions
+    instead.
   - Use the "since" field to select PRs prior to the latest tag to include in the release
   - Type "true" in the "since the last stable git tag" if you would like to include PRs since the last non-prerelease version tagged on the target repository and branch.
   - The workflow will use the GitHub API to find the relevant pull requests and make an appropriate changelog entry.

--- a/jupyter_releaser/__init__.py
+++ b/jupyter_releaser/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-__version__ = "0.23.0.dev0"
+__version__ = "0.22.3"

--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -53,7 +53,7 @@ with make_group("Handle RH_SINCE"):
         os.chdir(curr_dir)
 
 
-run_action("jupyter-releaser bump-version")
+run_action("jupyter-releaser bump-version --use-changelog-version")
 
 with make_group("Handle Check Release"):
     if check_release:

--- a/jupyter_releaser/actions/draft_release.py
+++ b/jupyter_releaser/actions/draft_release.py
@@ -53,7 +53,7 @@ with make_group("Handle RH_SINCE"):
         os.chdir(curr_dir)
 
 
-run_action("jupyter-releaser bump-version --use-changelog-version")
+run_action("jupyter-releaser bump-version")
 
 with make_group("Handle Check Release"):
     if check_release:

--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -335,7 +335,7 @@ def extract_current(changelog_path):
 def extract_current_version(changelog_path):
     """Extract the current released version from the changelog"""
     body = extract_current(changelog_path)
-    match = re.match(r"#+ ([\da-z.]+)", body.strip())
+    match = re.match(r"#+ ([\d.]+)", body.strip())
     if not match:
         raise ValueError("Could not find previous version")
     return match.groups()[0]

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -203,15 +203,6 @@ changelog_path_options = [
     ),
 ]
 
-use_changelog_version_options = [
-    click.option(
-        "--use-changelog-version",
-        envvar="RH_USE_CHANGELOG_VERSION",
-        is_flag=True,
-        help="Whether to use the changelog version if the current version is a dev version in version bump",
-    ),
-]
-
 since_options = [
     click.option(
         "--since",
@@ -309,17 +300,14 @@ def prep_git(ref, branch, repo, auth, username, git_url):
 @add_options(version_spec_options)
 @add_options(version_cmd_options)
 @add_options(changelog_path_options)
-@add_options(use_changelog_version_options)
 @add_options(python_packages_options)
 @use_checkout_dir()
-def bump_version(version_spec, version_cmd, changelog_path, use_changelog_version, python_packages):
+def bump_version(version_spec, version_cmd, changelog_path, python_packages):
     """Prep git and env variables and bump version"""
     prev_dir = os.getcwd()
     for python_package in [p.split(":")[0] for p in python_packages]:
         os.chdir(python_package)
-        lib.bump_version(
-            version_spec, version_cmd, changelog_path, use_changelog_version=use_changelog_version
-        )
+        lib.bump_version(version_spec, version_cmd, changelog_path)
         os.chdir(prev_dir)
 
 

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -141,16 +141,7 @@ version_spec_options = [
 ]
 
 version_cmd_options = [
-    click.option("--version-cmd", envvar="RH_VERSION_COMMAND", help="The version command"),
-]
-
-version_create_tag_options = [
-    click.option(
-        "--version-create-tag",
-        envvar="RH_VERSION_CREATE_TAG",
-        is_flag=True,
-        help="Whether to create a tag when bumping the version",
-    ),
+    click.option("--version-cmd", envvar="RH_VERSION_COMMAND", help="The version command")
 ]
 
 
@@ -317,19 +308,11 @@ def prep_git(ref, branch, repo, auth, username, git_url):
 @main.command()
 @add_options(version_spec_options)
 @add_options(version_cmd_options)
-@add_options(version_create_tag_options)
 @add_options(changelog_path_options)
 @add_options(use_changelog_version_options)
 @add_options(python_packages_options)
 @use_checkout_dir()
-def bump_version(
-    version_spec,
-    version_cmd,
-    version_create_tag,
-    changelog_path,
-    use_changelog_version,
-    python_packages,
-):
+def bump_version(version_spec, version_cmd, changelog_path, use_changelog_version, python_packages):
     """Prep git and env variables and bump version"""
     prev_dir = os.getcwd()
     for python_package in [p.split(":")[0] for p in python_packages]:
@@ -337,8 +320,6 @@ def bump_version(
         lib.bump_version(
             version_spec, version_cmd, changelog_path, use_changelog_version=use_changelog_version
         )
-        if version_create_tag:
-            lib.create_tag()
         os.chdir(prev_dir)
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -21,14 +21,9 @@ from pkginfo import SDist, Wheel
 from jupyter_releaser import changelog, npm, python, util
 
 
-def bump_version(version_spec, version_cmd, changelog_path, use_changelog_version):
+def bump_version(version_spec, version_cmd, changelog_path):
     """Bump the version and verify new version"""
-    util.bump_version(
-        version_spec,
-        version_cmd=version_cmd,
-        changelog_path=changelog_path,
-        use_changelog_version=use_changelog_version,
-    )
+    util.bump_version(version_spec, version_cmd=version_cmd, changelog_path=changelog_path)
 
     version = util.get_version()
 
@@ -255,10 +250,7 @@ def draft_release(
     # Bump to post version if given
     if post_version_spec:
         post_version = bump_version(
-            post_version_spec,
-            version_cmd=version_cmd,
-            changelog_path=changelog_path,
-            use_changelog_version=False,
+            post_version_spec, version_cmd=version_cmd, changelog_path=changelog_path
         )
         util.log(post_version_message.format(post_version=post_version))
         util.run(f'git commit -a -m "Bump to {post_version}"')

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -30,10 +30,7 @@ def bump_version(version_spec, version_cmd, changelog_path, use_changelog_versio
         use_changelog_version=use_changelog_version,
     )
 
-
-def create_tag():
     version = util.get_version()
-    assert version is not None
 
     # A properly parsed version will have a "major" attribute
     parsed = parse_version(version)
@@ -47,6 +44,7 @@ def create_tag():
         msg = f"Tag {tag_name} already exists!"
         msg += " To delete run: `git push --delete origin {tag_name}`"
         raise ValueError(msg)
+
     return version
 
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -144,10 +144,7 @@ def test_bump_version_tag_exists(py_package, runner):
     runner(["prep-git", "--git-url", py_package])
     run("git tag v1.0.1", cwd=util.CHECKOUT_NAME)
     with pytest.raises(ValueError):
-        runner(
-            ["bump-version", "--version-spec", "1.0.1", "--version-create-tag"],
-            env=dict(GITHUB_ACTIONS=""),
-        )
+        runner(["bump-version", "--version-spec", "1.0.1"], env=dict(GITHUB_ACTIONS=""))
 
 
 def test_list_envvars(runner):
@@ -186,7 +183,6 @@ twine-registry: TWINE_REGISTRY
 use-changelog-version: RH_USE_CHANGELOG_VERSION
 username: GITHUB_ACTOR
 version-cmd: RH_VERSION_COMMAND
-version-create-tag: RH_VERSION_CREATE_TAG
 version-spec: RH_VERSION_SPEC
 """.strip()
     )

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -127,13 +127,6 @@ def test_bump_version(npm_package, runner):
     assert version == "1.0.1-rc0"
 
 
-def test_bump_version_use_changelog(npm_package, runner):
-    runner(["prep-git", "--git-url", npm_package])
-    runner(["bump-version", "--use-changelog-version"])
-    version = util.get_version()
-    assert version == "1.0.0"
-
-
 def test_bump_version_bad_version(py_package, runner):
     runner(["prep-git", "--git-url", py_package])
     with pytest.raises(CalledProcessError):
@@ -180,7 +173,6 @@ tag-format: RH_TAG_FORMAT
 tag-message: RH_TAG_MESSAGE
 twine-cmd: TWINE_COMMAND
 twine-registry: TWINE_REGISTRY
-use-changelog-version: RH_USE_CHANGELOG_VERSION
 username: GITHUB_ACTOR
 version-cmd: RH_VERSION_COMMAND
 version-spec: RH_VERSION_SPEC

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -294,27 +294,17 @@ def test_bump_version_reg(py_package):
 
 
 def test_bump_version_dev(py_package):
-    changelog_path = py_package / "CHANGELOG.md"
     util.bump_version("dev")
     assert util.get_version() == "0.1.0.dev0"
     util.bump_version("dev")
     assert util.get_version() == "0.1.0.dev1"
     # Should get the version from the changelog
-    util.bump_version("next", changelog_path=changelog_path)
+    util.bump_version("next", changelog_path=py_package / "CHANGELOG.md")
     assert util.get_version() == "0.0.2"
     util.bump_version("dev")
     assert util.get_version() == "0.1.0.dev0"
-    util.bump_version("patch", changelog_path=changelog_path, use_changelog_version=True)
-    assert util.get_version() == "0.0.1"
-    util.bump_version("1.0.0.dev0")
-    text = changelog_path.read_text(encoding="utf-8")
-    text = text.replace("0.0.1", "0.0.1a1")
-    changelog_path.write_text(text, encoding="utf-8")
-    util.bump_version("patch", changelog_path=changelog_path)
-    assert util.get_version() == "0.0.1a2"
-    util.bump_version("1.0.0.dev0")
-    util.bump_version("patch", changelog_path=changelog_path, use_changelog_version=True)
-    assert util.get_version() == "0.0.1a1"
+    util.bump_version("patch", changelog_path=py_package / "CHANGELOG.md")
+    assert util.get_version() == "0.0.2"
     util.bump_version("1.0.0.dev0")
     util.bump_version("minor")
     assert util.get_version() == "1.0.0"

--- a/jupyter_releaser/tests/test_functions.py
+++ b/jupyter_releaser/tests/test_functions.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from pathlib import Path
 
+import pytest
 import toml
 from ghapi.core import GhApi
 
@@ -298,16 +299,12 @@ def test_bump_version_dev(py_package):
     assert util.get_version() == "0.1.0.dev0"
     util.bump_version("dev")
     assert util.get_version() == "0.1.0.dev1"
-    # Should get the version from the changelog
-    util.bump_version("next", changelog_path=py_package / "CHANGELOG.md")
-    assert util.get_version() == "0.0.2"
-    util.bump_version("dev")
-    assert util.get_version() == "0.1.0.dev0"
-    util.bump_version("patch", changelog_path=py_package / "CHANGELOG.md")
-    assert util.get_version() == "0.0.2"
-    util.bump_version("1.0.0.dev0")
+    with pytest.raises(ValueError):
+        util.bump_version("next")
+    with pytest.raises(ValueError):
+        util.bump_version("patch")
     util.bump_version("minor")
-    assert util.get_version() == "1.0.0"
+    assert util.get_version() == "0.1.0"
 
 
 def test_get_config_python(py_package):

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -231,7 +231,7 @@ def create_release_commit(version, release_message=None, dist_dir="dist"):
     return shas
 
 
-def bump_version(version_spec, *, changelog_path="", version_cmd="", use_changelog_version=False):
+def bump_version(version_spec, *, changelog_path="", version_cmd=""):
     """Bump the version"""
     # Look for config files to determine version command if not given
     if not version_cmd:
@@ -275,15 +275,7 @@ def bump_version(version_spec, *, changelog_path="", version_cmd="", use_changel
 
                 v = parse_version(extract_current_version(changelog_path))
                 assert isinstance(v, Version)
-                if use_changelog_version:
-                    version_spec = v
-                elif v.is_prerelease:
-                    assert v.pre
-                    # Bump to the next prerelease.
-                    version_spec = f"{v.major}.{v.minor}.{v.micro}{v.pre[0]}{v.pre[1] + 1}"
-                else:
-                    # Bump to the next micro.
-                    version_spec = f"{v.major}.{v.minor}.{v.micro + 1}"
+                version_spec = f"{v.major}.{v.minor}.{v.micro + 1}"
 
             # Drop the dev portion and move to the minor release.
             elif version_spec == "minor":

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -271,11 +271,9 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):
         if v.is_devrelease:
             # bump from the version in the changelog.
             if version_spec in ["patch", "next"]:
-                from jupyter_releaser.changelog import extract_current_version
-
-                v = parse_version(extract_current_version(changelog_path))
-                assert isinstance(v, Version)
-                version_spec = f"{v.major}.{v.minor}.{v.micro + 1}"
+                raise ValueError(
+                    "We do not support 'patch' or 'next' when dev versions are used, please use an explicit version."
+                )
 
             # Drop the dev portion and move to the minor release.
             elif version_spec == "minor":

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -59,7 +59,7 @@ def run(cmd, **kwargs):
     quiet_error = kwargs.pop("quiet_error", False)
     show_cwd = kwargs.pop("show_cwd", False)
     quiet = kwargs.pop("quiet", False)
-    echo = kwargs.pop("echo", True)
+    echo = kwargs.pop("echo", False)
 
     if echo:
         prefix = "COMMAND"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_releaser"
-version = "0.23.0.dev0"
+version = "0.22.3"
 description = "Jupyter Releaser for Python and/or npm packages."
 license = {file = "LICENSE"}
 authors = [{name = "Jupyter Development Team", email = "jupyter@googlegroups.com"}]
@@ -58,7 +58,7 @@ test = [
 jupyter-releaser = "jupyter_releaser.cli:main"
 
 [tool.tbump.version]
-current = "0.23.0.dev0"
+current = "0.22.3"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
@@ -79,9 +79,6 @@ src = "docs/source/conf.py"
 
 [tool.jupyter-releaser]
 skip = ["check-links"]
-
-[tool.jupyter-releaser.options]
-post-version-spec = "dev"
 
 [tool.jupyter-releaser.hooks]
 after-draft-release = "bash ./.github/scripts/bump_tag.sh"


### PR DESCRIPTION
For now we disallow the use of "next" or "patch" when dev versions are used, until we can implement a proper fix as part of #272 