### PR TITLE
Use version template in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ src = "jupyter_releaser/__init__.py"
 
 [[tool.tbump.file]]
 src = "pyproject.toml"
+version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\""
 
 [[tool.tbump.file]]
 src = "docs/source/conf.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,14 @@ version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\""
 [[tool.tbump.file]]
 src = "docs/source/conf.py"
 
+[[tool.tbump.field]]
+name = "channel"
+default = ""
+
+[[tool.tbump.field]]
+name = "release"
+default = ""
+
 [tool.jupyter-releaser]
 skip = ["check-links"]
 


### PR DESCRIPTION
To avoid accidentally bumping a dependency version