### PR TITLE
Revert to using stash apply instead of merge

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -172,7 +172,7 @@ def make_changelog_pr(auth, branch, repo, title, commit_message, body, dry_run=F
         pass
     util.run(f"git checkout -b {pr_branch} origin/{branch}", echo=True)
     if dirty:
-        util.run("git merge --squash --strategy-option=theirs stash", echo=True)
+        util.run("git stash apply", echo=True)
 
     # Add a commit with the message
     try:


### PR DESCRIPTION
In #358, the logic to create the changelog PR was updated to use `git merge` instead `git stash` (presumably to be more robust in case of changes are pulled from the upstream branch).

In JupyterLab, this results in the bump by lerna of node packages to be committed with the Changelog changes as a commit is done automatically by lerna in the bump version step. The reason is that the merge command on the stash branch is bringing in more than the change stashed.

Failing PR example: https://github.com/jupyterlab/jupyterlab/pull/12932