### PR TITLE
Fix the input parameter since_last_stable when running a full release

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -53,7 +53,7 @@ jobs:
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           since: ${{ github.event.inputs.since }}
-          since_last_stable: ${{ github.event.intputs.since_last_stable }}
+          since_last_stable: ${{ github.event.inputs.since_last_stable }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
 
       - name: Publish Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ filterwarnings= [
   # Fail on warnings
   "error",
   "ignore:Using deprecated setup.py invocation:UserWarning",
+  "module:Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found: running as unauthenticated:UserWarning",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ filterwarnings= [
   # Fail on warnings
   "error",
   "ignore:Using deprecated setup.py invocation:UserWarning",
-  "ignore:Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found: running as unauthenticated:UserWarning",
+  "module:Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found:UserWarning",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ filterwarnings= [
   # Fail on warnings
   "error",
   "ignore:Using deprecated setup.py invocation:UserWarning",
-  "module:Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found: running as unauthenticated:UserWarning",
+  "ignore:Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found: running as unauthenticated:UserWarning",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Fixes a typo in *.github/workflows/full-release.yml*, which makes the `since_last_stable` parameter unusable (and causes the job to fail if the *changelog* was built using this parameter).