### PR TITLE
Use "hatchling version" as a version command where applicable

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import importlib.metadata
 import os.path as osp
 import shutil
 
@@ -23,7 +24,7 @@ copyright = "2021, Project Jupyter"
 author = "Project Jupyter"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.23.3"
+release = importlib.metadata.version("jupyter_releaser")
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -248,9 +248,9 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):
 
         if PYPROJECT.exists():
             pyproject_text = PYPROJECT.read_text(encoding="utf-8")
-            if "tbump" in pyproject_text:
+            if "tool.tbump" in pyproject_text:
                 version_cmd = version_cmd or TBUMP_CMD
-            elif "hatchling" in pyproject_text:
+            elif "hatchling.build" in pyproject_text:
                 version_cmd = version_cmd or "hatchling version"
 
         if SETUP_CFG.exists():

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -251,7 +251,7 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):
             if "tbump" in pyproject_text:
                 version_cmd = version_cmd or TBUMP_CMD
             elif "hatchling" in pyproject_text:
-                version_cmd = version_cmd or "hatch version"
+                version_cmd = version_cmd or "hatchling version"
 
         if SETUP_CFG.exists():
             if "bumpversion" in SETUP_CFG.read_text(encoding="utf-8"):
@@ -265,13 +265,13 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):
 
     # Assign default values if no version spec was given
     if not version_spec:
-        if "tbump" in version_cmd or "hatch" in version_cmd:
+        if "tbump" in version_cmd or "hatchling" in version_cmd:
             version_spec = "next"
         else:
             version_spec = "patch"
 
     # Add some convenience options on top of "tbump" and "hatch"
-    if "tbump" in version_cmd or "hatch" in version_cmd:
+    if "tbump" in version_cmd or "hatchling" in version_cmd:
         v = parse_version(get_version())
         assert isinstance(v, Version)
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -247,8 +247,11 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):
             version_cmd = version_cmd or TBUMP_CMD
 
         if PYPROJECT.exists():
-            if "tbump" in PYPROJECT.read_text(encoding="utf-8"):
+            pyproject_text = PYPROJECT.read_text(encoding="utf-8")
+            if "tbump" in pyproject_text:
                 version_cmd = version_cmd or TBUMP_CMD
+            elif "hatchling" in pyproject_text:
+                version_cmd = version_cmd or "hatch version"
 
         if SETUP_CFG.exists():
             if "bumpversion" in SETUP_CFG.read_text(encoding="utf-8"):
@@ -262,13 +265,13 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):
 
     # Assign default values if no version spec was given
     if not version_spec:
-        if "tbump" in version_cmd:
+        if "tbump" in version_cmd or "hatch" in version_cmd:
             version_spec = "next"
         else:
             version_spec = "patch"
 
-    # Add some convenience options on top of "tbump"
-    if "tbump" in version_cmd:
+    # Add some convenience options on top of "tbump" and "hatch"
+    if "tbump" in version_cmd or "hatch" in version_cmd:
         v = parse_version(get_version())
         assert isinstance(v, Version)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_releaser"
-version = "0.23.3"
 description = "Jupyter Releaser for Python and/or npm packages."
 license = {file = "LICENSE"}
 authors = [{name = "Jupyter Development Team", email = "jupyter@googlegroups.com"}]
@@ -21,6 +20,7 @@ classifiers = [
 ]
 urls = {Homepage = "https://jupyter.org"}
 requires-python = ">=3.8"
+dynamic = ["version"]
 dependencies = [
     "build",
     "check-manifest",
@@ -59,34 +59,8 @@ test = [
 [project.scripts]
 jupyter-releaser = "jupyter_releaser.cli:main"
 
-[tool.tbump.version]
-current = "0.23.3"
-regex = '''
-  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
-'''
-
-[tool.tbump.git]
-message_template = "Bump to {new_version}"
-tag_template = "v{new_version}"
-
-[[tool.tbump.file]]
-src = "jupyter_releaser/__init__.py"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\""
-
-[[tool.tbump.file]]
-src = "docs/source/conf.py"
-
-[[tool.tbump.field]]
-name = "channel"
-default = ""
-
-[[tool.tbump.field]]
-name = "release"
-default = ""
+[tool.hatch.version]
+path = "jupyter_releaser/__init__.py"
 
 [tool.jupyter-releaser]
 skip = ["check-links"]


### PR DESCRIPTION
Use "hatch version" as a default if there is no tbump config.

Will have to wait for #363 to be merged.