### PR TITLE
Fix publish-release

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/publish-release
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
           release_url: ${{ steps.draft-release.outputs.release_url }}
 
       - name: "** Next Step **"

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -169,7 +169,7 @@ def draft_changelog(
         current_sha=current_sha,
     )
     with tempfile.TemporaryDirectory() as d:
-        metadata_path = Path(d) / "metadata.json"
+        metadata_path = Path(d) / util.METADATA_JSON
         with open(metadata_path, "w") as fid:
             json.dump(data, fid)
 
@@ -432,7 +432,7 @@ def extract_release(
     commit_message = ""
     commit_message = util.run(f"git log --format=%B -n 1 {sha}")
 
-    for asset in assets:
+    for asset in filter(lambda a: a.name != util.METADATA_JSON.name, assets):
         # Check the sha against the published sha
         valid = False
         path = dist / asset.name

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -465,7 +465,9 @@ def extract_metadata_from_release_url(gh, release_url, auth):
         data = json.loads(sink.read().decode("utf-8"))
 
     if data is None:
-        raise ValueError(f'Could not find "{METADATA_JSON.name}" file in draft release {release_url}')
+        raise ValueError(
+            f'Could not find "{METADATA_JSON.name}" file in draft release {release_url}'
+        )
 
     # Update environment variables.
     if "post_version_spec" in data:

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -39,6 +39,7 @@ PACKAGE_JSON = Path("package.json")
 MANIFEST = Path("MANIFEST.in")
 YARN_LOCK = Path("yarn.lock")
 JUPYTER_RELEASER_CONFIG = Path(".jupyter-releaser.toml")
+METADATA_JSON = Path("metadata.json")
 
 BUF_SIZE = 65536
 TBUMP_CMD = "tbump --non-interactive --only-patch"
@@ -448,7 +449,7 @@ def extract_metadata_from_release_url(gh, release_url, auth):
 
     data = None
     for asset in release.assets:
-        if asset.name != "metadata.json":
+        if asset.name != METADATA_JSON.name:
             continue
 
         log(f"Fetching {asset.name}...")
@@ -464,7 +465,7 @@ def extract_metadata_from_release_url(gh, release_url, auth):
         data = json.loads(sink.read().decode("utf-8"))
 
     if data is None:
-        raise ValueError(f'Could not find "metadata.json" file in draft release {release_url}')
+        raise ValueError(f'Could not find "{METADATA_JSON.name}" file in draft release {release_url}')
 
     # Update environment variables.
     if "post_version_spec" in data:


### PR DESCRIPTION
This fixes is based on using the new version to release JLab 3.4.7:

- `target` not pass to _publish-release_
  Should we pass `steps_to_skip` too? It seems not as there is only one step - so probably that input should be remove from standalone workflow _Publish Release_
- `metadata.json` was not ignored from the sha check loop

> I created a constant storing `metadata.json` in `util.py`.