### PR TITLE
Clean up Extract Release

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -585,30 +585,14 @@ def delete_release(auth, dry_run, release_url):
 @add_options(auth_options)
 @add_options(dist_dir_options)
 @add_options(dry_run_options)
-@add_options(npm_install_options)
-@add_options(pydist_check_options)
-@add_options(check_imports_options)
 @add_options(release_url_options)
-def extract_release(
-    auth,
-    dist_dir,
-    dry_run,
-    release_url,
-    npm_install_options,
-    pydist_check_cmd,
-    pydist_resource_paths,
-    check_imports,
-):
+def extract_release(auth, dist_dir, dry_run, release_url):
     """Download and verify assets from a draft GitHub release"""
     lib.extract_release(
         auth,
         dist_dir,
         dry_run,
         release_url,
-        npm_install_options,
-        pydist_check_cmd,
-        pydist_resource_paths,
-        check_imports,
     )
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -12,7 +12,6 @@ from glob import glob
 from pathlib import Path
 from subprocess import CalledProcessError
 
-import requests
 import toml
 from packaging.version import parse as parse_version
 from pkginfo import SDist, Wheel

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -249,8 +249,10 @@ def draft_release(
 
     # Upload the assets to the draft release.
     util.log(f"Uploading assets: {assets}")
+    asset_shas = {}
     for fpath in assets:
         gh.upload_file(release, fpath)
+        asset_shas[os.path.basename(fpath)] = util.compute_sha256(fpath)
 
     # Set the body of the release with the changelog contents.
     # Get the new release since the draft release might change urls.
@@ -263,6 +265,15 @@ def draft_release(
         True,
         release.prerelease,
     )
+
+    # Update the metadata file to include the shas
+    assets = release.assets
+    for asset in assets:
+        if asset.name == "metadata.json":
+            with tempfile.TemporaryDirectory() as td:
+                metadata = util.fetch_release_asset(td, asset, auth)
+                metadata["asset_shas"] = asset_shas
+                gh.upload_file(release, os.path.join(td, "metadata.json"))
 
     # Set the GitHub action output
     util.actions_output("release_url", release.html_url)
@@ -283,16 +294,7 @@ def delete_release(auth, release_url, dry_run=False):
     gh.repos.delete_release(release.id)
 
 
-def extract_release(
-    auth,
-    dist_dir,
-    dry_run,
-    release_url,
-    npm_install_options,
-    pydist_check_cmd,
-    pydist_resource_paths,
-    python_imports,
-):
+def extract_release(auth, dist_dir, dry_run, release_url):
     """Download and verify assets from a draft GitHub release"""
     match = util.parse_release_url(release_url)
     owner, repo = match["owner"], match["repo"]
@@ -308,11 +310,6 @@ def extract_release(
     orig_dir = os.getcwd()
     os.chdir(util.CHECKOUT_NAME)
 
-    # Read in the config
-    config = util.read_config()
-    options = config.get("options", {})
-    npm_install_options = npm_install_options or options.get("npm-install-options", "")
-
     # Clean the dist folder
     dist = Path(dist_dir)
     if dist.exists():
@@ -321,68 +318,21 @@ def extract_release(
 
     # Fetch, validate, and publish assets
     for asset in assets:
-        util.log(f"Fetching {asset.name}...")
-        url = asset.url
-        headers = dict(Authorization=f"token {auth}", Accept="application/octet-stream")
-        path = dist / asset.name
-        with requests.get(url, headers=headers, stream=True) as r:
-            r.raise_for_status()
-            with open(path, "wb") as f:
-                for chunk in r.iter_content(chunk_size=8192):
-                    f.write(chunk)
+        util.fetch_release_asset(dist_dir, asset, auth)
 
-    # Check all npm packages
-    npm.check_dist(dist, npm_install_options)
+    # Validate the shas of all the files
+    metadata_file = dist / "metadata.json"
+    with open(metadata_file) as fid:
+        asset_shas = json.load(fid)["asset_shas"]
+    metadata_file.unlink()
 
-    # Check python packages individually
     for asset in assets:
-        suffix = Path(asset.name).suffix
-        if suffix in [".gz", ".whl"]:
-            python.check_dist(
-                dist / asset.name,
-                check_cmd=pydist_check_cmd,
-                python_imports=python_imports,
-                resource_paths=pydist_resource_paths,
-            )
-        elif suffix == ".tgz":
-            pass  # already handled
-        else:
-            util.log(f"Nothing to check for {asset.name}")
-
-    # Skip sha validation for dry runs since the remote tag will not exist
-    if dry_run:
-        os.chdir(orig_dir)
-        return
-
-    tag_name = release.tag_name
-
-    sha = None
-    for tag in gh.list_tags(tag_name):
-        if tag.ref == f"refs/tags/{tag_name}":
-            sha = tag.object.sha
-            break
-    if sha is None:
-        raise ValueError("Could not find tag")
-
-    # Get the commmit message for the tag
-    commit_message = ""
-    commit_message = util.run(f"git log --format=%B -n 1 {sha}")
-
-    for asset in filter(lambda a: a.name != util.METADATA_JSON.name, assets):
-        # Check the sha against the published sha
-        valid = False
-        path = dist / asset.name
-        sha = util.compute_sha256(path)
-
-        for line in commit_message.splitlines():
-            if asset.name in line:
-                if sha in line:
-                    valid = True
-                else:
-                    util.log("Mismatched sha!")
-
-        if not valid:  # pragma: no cover
-            raise ValueError(f"Invalid file {asset.name}")
+        if asset.name == "metadata.json":
+            continue
+        if asset.name not in asset_shas:
+            raise ValueError(f"{asset.name} was not found in metadata file")
+        if util.compute_sha256(dist / asset.name) != asset_shas[asset.name]:
+            raise ValueError(f"sha for {asset.name} does not match metadata file")
 
     os.chdir(orig_dir)
 

--- a/jupyter_releaser/python.py
+++ b/jupyter_releaser/python.py
@@ -25,11 +25,7 @@ def build_dist(dist_dir, clean=True):
         for pkg in glob(f"{dest}/*.gz") + glob(f"{dest}/*.whl"):
             os.remove(pkg)
 
-    if PYPROJECT.exists():
-        util.run(f"pipx run build --outdir {dest} .", quiet=True, show_cwd=True)
-    elif SETUP_PY.exists():
-        util.run(f"python setup.py sdist --dist-dir {dest}", quiet=True)
-        util.run(f"python setup.py bdist_wheel --dist-dir {dest}", quiet=True)
+    util.run(f"pipx run build --outdir {dest} .", quiet=True, show_cwd=True)
 
 
 def check_dist(

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -18,7 +18,6 @@ from jupyter_releaser.tests.util import (
     PR_ENTRY,
     VERSION_SPEC,
     create_draft_release,
-    create_tag_ref,
     get_log,
     mock_changelog_entry,
 )
@@ -516,13 +515,10 @@ def test_extract_dist_py(py_package, runner, mocker, mock_github, tmp_path, git_
     # Finalize the release
     runner(["tag-release"])
 
-    # Create a tag ref
-    ref = create_tag_ref()
-
     # Create the release.
     dist_dir = os.path.join(util.CHECKOUT_NAME, "dist")
-    release = create_draft_release(ref, glob(f"{dist_dir}/*.*"))
-    shutil.rmtree(f"{util.CHECKOUT_NAME}/dist")
+    release = create_draft_release("bar", glob(f"{dist_dir}/*.*"))
+    shutil.rmtree(dist_dir)
 
     os.environ["RH_RELEASE_URL"] = release.html_url
     runner(["extract-release"])
@@ -553,14 +549,10 @@ def test_extract_dist_multipy(py_multipackage, runner, mocker, mock_github, tmp_
     # Finalize the release
     runner(["tag-release"])
 
-    # Create a tag ref
-    ref = create_tag_ref()
-
     # Create the release.
     dist_dir = os.path.join(util.CHECKOUT_NAME, "dist")
-    release = create_draft_release(ref, glob(f"{dist_dir}/*.*"))
-
-    shutil.rmtree(f"{util.CHECKOUT_NAME}/dist")
+    release = create_draft_release("bar", glob(f"{dist_dir}/*.*"))
+    shutil.rmtree(dist_dir)
 
     os.environ["RH_RELEASE_URL"] = release.html_url
     runner(["extract-release"])
@@ -575,13 +567,10 @@ def test_extract_dist_multipy(py_multipackage, runner, mocker, mock_github, tmp_
     reason="See https://bugs.python.org/issue26660",
 )
 def test_extract_dist_npm(npm_dist, runner, mocker, mock_github, tmp_path):
-    # Create a tag ref
-    ref = create_tag_ref()
-
     # Create the release.
     dist_dir = os.path.join(util.CHECKOUT_NAME, "dist")
-    release = create_draft_release(ref, glob(f"{dist_dir}/*.*"))
-    shutil.rmtree(f"{util.CHECKOUT_NAME}/dist")
+    release = create_draft_release("bar", glob(f"{dist_dir}/*.*"))
+    shutil.rmtree(dist_dir)
 
     os.environ["RH_RELEASE_URL"] = release.html_url
     runner(["extract-release"])
@@ -612,7 +601,7 @@ def test_publish_assets_py(py_package, runner, mocker, git_prep, mock_github):
     mock_run = mocker.patch("jupyter_releaser.util.run", wraps=wrapped)
 
     dist_dir = py_package / util.CHECKOUT_NAME / "dist"
-    release = create_draft_release()
+    release = create_draft_release(files=glob(f"{dist_dir}/*.*"))
     os.environ["RH_RELEASE_URL"] = release.html_url
     runner(["publish-assets", "--dist-dir", dist_dir, "--dry-run"])
     assert called == 2, called

--- a/jupyter_releaser/tests/util.py
+++ b/jupyter_releaser/tests/util.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ghapi.core import GhApi
 
 from jupyter_releaser import changelog, cli, util
-from jupyter_releaser.util import get_latest_tag, run
+from jupyter_releaser.util import run
 
 VERSION_SPEC = "1.0.1"
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -448,12 +448,51 @@ def fetch_release_asset(target_dir, asset, auth):
     log(f"Fetching {asset.name}...")
     url = asset.url
     headers = dict(Authorization=f"token {auth}", Accept="application/octet-stream")
-    path = target_dir / asset.name
+    path = Path(target_dir) / asset.name
     with requests.get(url, headers=headers, stream=True) as r:
         r.raise_for_status()
         with open(path, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
+    return path
+
+
+def fetch_release_asset_data(asset, auth):
+    """Fetch the data for a release asset."""
+    log(f"Fetching data for {asset.name}...")
+    url = asset.url
+    headers = dict(Authorization=f"token {auth}", Accept="application/octet-stream")
+
+    sink = BytesIO()
+    with requests.get(url, headers=headers, stream=True) as r:
+        r.raise_for_status()
+        for chunk in r.iter_content(chunk_size=8192):
+            sink.write(chunk)
+    sink.seek(0)
+    return json.loads(sink.read().decode("utf-8"))
+
+
+def upload_assets(gh, assets, release, auth):
+    """Upload assets to a release."""
+    log(f"Uploading assets: {assets}")
+    asset_shas = {}
+    for fpath in assets:
+        gh.upload_file(release, fpath)
+        asset_shas[os.path.basename(fpath)] = compute_sha256(fpath)
+
+    # Update the metadata file to include the shas
+    for asset in release.assets:
+        if asset.name == "metadata.json":
+            with tempfile.TemporaryDirectory() as td:
+                metadata_file = fetch_release_asset(td, asset, auth)
+                with open(metadata_file) as fid:
+                    metadata = json.load(fid)
+                metadata["asset_shas"] = asset_shas
+                with open(metadata_file, "w") as fid:
+                    json.dump(metadata, fid)
+                gh.upload_file(release, os.path.join(td, "metadata.json"))
+
+    return release
 
 
 def extract_metadata_from_release_url(gh, release_url, auth):
@@ -465,17 +504,7 @@ def extract_metadata_from_release_url(gh, release_url, auth):
         if asset.name != METADATA_JSON.name:
             continue
 
-        log(f"Fetching {asset.name}...")
-        url = asset.url
-        headers = dict(Authorization=f"token {auth}", Accept="application/octet-stream")
-
-        sink = BytesIO()
-        with requests.get(url, headers=headers, stream=True) as r:
-            r.raise_for_status()
-            for chunk in r.iter_content(chunk_size=8192):
-                sink.write(chunk)
-        sink.seek(0)
-        data = json.loads(sink.read().decode("utf-8"))
+        data = fetch_release_asset_data(asset, auth)
 
     if data is None:
         raise ValueError(

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -443,6 +443,19 @@ def parse_release_url(release_url):
     return match
 
 
+def fetch_release_asset(target_dir, asset, auth):
+    """Fetch a release asset into a target directory."""
+    log(f"Fetching {asset.name}...")
+    url = asset.url
+    headers = dict(Authorization=f"token {auth}", Accept="application/octet-stream")
+    path = target_dir / asset.name
+    with requests.get(url, headers=headers, stream=True) as r:
+        r.raise_for_status()
+        with open(path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+
 def extract_metadata_from_release_url(gh, release_url, auth):
     log(f"Extracting metadata for release: {release_url}")
     release = release_for_url(gh, release_url)


### PR DESCRIPTION
Include the shas of the files when uploading.  Compare against those shas in extract release rather than against the commit message.  Also do not re-check the dist files since we already did that before uploading.