### PR TITLE
Clean up asset sha handling

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -53,3 +53,4 @@ jobs:
           echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"
           echo "## Next Step" >> $GITHUB_STEP_SUMMARY
           echo "(Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "Run Step 2: Publish Release workflow"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ on:
         required: false
 
 jobs:
-  full_release:
+  publish_release:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -288,18 +288,18 @@ def extract_release(auth, dist_dir, dry_run, release_url):
         util.fetch_release_asset(dist_dir, asset, auth)
 
     # Validate the shas of all the files
-    metadata_file = dist / "metadata.json"
-    with open(metadata_file) as fid:
-        asset_shas = json.load(fid)["asset_shas"]
-    metadata_file.unlink()
+    asset_shas_file = dist / "asset_shas.json"
+    with open(asset_shas_file) as fid:
+        asset_shas = json.load(fid)
+    asset_shas_file.unlink()
 
     for asset in assets:
-        if asset.name == "metadata.json":
+        if asset.name.endswith(".json"):
             continue
         if asset.name not in asset_shas:
-            raise ValueError(f"{asset.name} was not found in metadata file")
+            raise ValueError(f"{asset.name} was not found in asset_shas file")
         if util.compute_sha256(dist / asset.name) != asset_shas[asset.name]:
-            raise ValueError(f"sha for {asset.name} does not match metadata file")
+            raise ValueError(f"sha for {asset.name} does not match asset_shas file")
 
     os.chdir(orig_dir)
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -480,17 +480,12 @@ def upload_assets(gh, assets, release, auth):
         gh.upload_file(release, fpath)
         asset_shas[os.path.basename(fpath)] = compute_sha256(fpath)
 
-    # Update the metadata file to include the shas
-    for asset in release.assets:
-        if asset.name == "metadata.json":
-            with tempfile.TemporaryDirectory() as td:
-                metadata_file = fetch_release_asset(td, asset, auth)
-                with open(metadata_file) as fid:
-                    metadata = json.load(fid)
-                metadata["asset_shas"] = asset_shas
-                with open(metadata_file, "w") as fid:
-                    json.dump(metadata, fid)
-                gh.upload_file(release, os.path.join(td, "metadata.json"))
+    # Create an asset_shas file.
+    with tempfile.TemporaryDirectory() as td:
+        asset_shas_file = os.path.join(td, "asset_shas.json")
+        with open(asset_shas_file, "w") as fid:
+            json.dump(asset_shas, fid)
+        gh.upload_file(release, asset_shas_file)
 
     return release
 


### PR DESCRIPTION
Create a new file so we do not hit a 422 error when trying to re-upload `metadata.json`.  This is cleaner anyway since the metadata file becomes environment variables.

I'm testing the version2 workflows with https://github.com/blink1073/test-python-project.  So far prep release worked but publish release failed with the 422 error.