### PR TITLE
Fix handling of `GITHUB_OUTPUT`

### DIFF
--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -398,7 +398,7 @@ def actions_output(name, value):
     """Handle setting an action output on GitHub"""
     log(f"\n\nSetting output {name}={value}")
     if "GITHUB_OUTPUT" in os.environ:
-        with open("GITHUB_OUTPUT", "a") as fid:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as fid:
             fid.write(f"{name}={value}\n")
 
 


### PR DESCRIPTION
Attempt at fixing https://github.com/jupyter-server/jupyter_releaser/pull/444/files#r999693330

Otherwise it looks like a file named `GITHUB_OUTPUT` is being created on disk: https://github.com/jupyter/notebook/pull/6579#issuecomment-1283931797