### PR TITLE
Enable tasklist myst extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ try:
 except ImportError:
     pass
 
-myst_enable_extensions = ["html_image"]
+myst_enable_extensions = ["html_image", "tasklist"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
Nicer rerndering of tasks lists in docs see https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#task-lists

| Before | After |
|---|---|
| ![Screenshot from 2022-12-28 14-51-13](https://user-images.githubusercontent.com/5832902/209830056-4fd8fd20-a1f2-477f-b9c3-fc8f6c15b407.png) | ![Screenshot from 2022-12-28 14-50-59](https://user-images.githubusercontent.com/5832902/209830081-4aaa7e78-4d5b-41bb-bea2-097ff7072f56.png) |
