### PR TITLE
Add whitelist for http request in yarn

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -39,6 +39,7 @@ runs:
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_RELEASE_URL=${{ steps.prep-release.outputs.release_url }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
+        export YARN_UNSAFE_HTTP_WHITELIST=0.0.0.0
         python -m jupyter_releaser.actions.populate_release
 
     - id: finalize-release


### PR DESCRIPTION
Working at updating `jlpm` to yarn3, the check release action is failing because yarn3 does not allow accessing an `http` resource without whitelist setting.

Would it be possible to add a new tagged version including this ?