### PR TITLE
Fix doc edition links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,8 +81,8 @@ html_theme_options = {
 
 # Output for github to be used in links
 html_context = {
-    "github_user": "jupyterlab",  # Username
-    "github_repo": "jupyterlab_server",  # Repo name
+    "github_user": "jupyter-server",  # Username
+    "github_repo": "jupyter_releaser",  # Repo name
     "github_version": "main",  # Version
     "doc_path": "/docs/source/",  # Path in the checkout to the docs root
 }


### PR DESCRIPTION
When clicking on the edition link on read the docs, we are currently redirected to `jupyterlab/jupyterlab_server`. This fixes it.