### PR TITLE
Use a PR for Release Commits

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -17,7 +17,8 @@ runs:
     - id: install-releaser
       shell: bash
       run: |
-        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -20,15 +20,7 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            echo "${{ github.action_path }}"
-            cd "${{ github.action_path }}"
-            cd ..
-            pwd
-            ls
-            cd ..
-            pwd
-            ls
-            pip install -q git+https://github.com/blink1073/jupyter_releaser.git@use-pr-for-changes
+            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
         fi
 
     - id: prep-release

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -29,6 +29,7 @@ runs:
       shell: bash -eux {0}
       run: |
         export RH_DRY_RUN="true"
+        export RH_GIT_URL=$(pwd)/.local_bare_repo
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_VERSION_SPEC=${{ inputs.version_spec }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
@@ -38,6 +39,7 @@ runs:
       shell: bash -eux {0}
       run: |
         export RH_DRY_RUN="true"
+        export RH_GIT_URL=$(pwd)/.local_bare_repo
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_RELEASE_URL=${{ steps.prep-release.outputs.release_url }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
@@ -48,6 +50,7 @@ runs:
       shell: bash -eux {0}
       run: |
         export RH_DRY_RUN="true"
+        export RH_GIT_URL=$(pwd)/.local_bare_repo
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_RELEASE_URL=${{ steps.populate-release.outputs.release_url }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -14,16 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash -eux {0}
-      id: install-releaser
-      run: |
-        # Install Jupyter Releaser if it is not already installed
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            cd "${{ github.action_path }}"
-            cd ../../..
-            pip install -e .
-        fi
+    - uses: ../install-releaser
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -17,10 +17,12 @@ runs:
     - shell: bash -eux {0}
       id: install-releaser
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
+        # Install Jupyter Releaser if it is not already installed
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
+            cd "${{ github.action_path }}"
+            cd ../../..
+            pip install -e .
         fi
 
     - id: prep-release

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -15,6 +15,7 @@ runs:
   using: "composite"
   steps:
     - id: install-releaser
+      shell: bash
       run: |
         bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -29,7 +29,6 @@ runs:
       shell: bash -eux {0}
       run: |
         export RH_DRY_RUN="true"
-        export RH_GIT_URL=$(pwd)/.local_bare_repo
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_VERSION_SPEC=${{ inputs.version_spec }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
@@ -39,7 +38,6 @@ runs:
       shell: bash -eux {0}
       run: |
         export RH_DRY_RUN="true"
-        export RH_GIT_URL=$(pwd)/.local_bare_repo
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_RELEASE_URL=${{ steps.prep-release.outputs.release_url }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
@@ -50,7 +48,6 @@ runs:
       shell: bash -eux {0}
       run: |
         export RH_DRY_RUN="true"
-        export RH_GIT_URL=$(pwd)/.local_bare_repo
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export RH_RELEASE_URL=${{ steps.populate-release.outputs.release_url }}
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -14,7 +14,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: ../install-releaser
+    - id: install-releaser
+      run: |
+        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -32,7 +32,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: ../install-releaser
+    - name: install-releaser
+      run: |
+        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 
     - id: finalize-release
       shell: bash -eux {0}

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -33,6 +33,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
+      shell: bash
       run: |
         bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -35,10 +35,12 @@ runs:
     - name: install-releaser
       shell: bash -eux {0}
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
+        # Install Jupyter Releaser if it is not already installed
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
+            cd "${{ github.action_path }}"
+            cd ../../..
+            pip install -e .
         fi
 
     - id: finalize-release

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -38,7 +38,7 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/blink1073/jupyter_releaser.git@use-pr-for-changes
+            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
         fi
 
     - id: finalize-release

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -35,7 +35,8 @@ runs:
     - name: install-releaser
       shell: bash
       run: |
-        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: finalize-release
       shell: bash -eux {0}

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -32,16 +32,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
-      run: |
-        # Install Jupyter Releaser if it is not already installed
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            cd "${{ github.action_path }}"
-            cd ../../..
-            pip install -e .
-        fi
+    - uses: ../install-releaser
 
     - id: finalize-release
       shell: bash -eux {0}

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: "GitHub access token"
     required: true
+  personal_access_token:
+    description: "GitHub PAT used to create pull requests"
+    required: false
   target:
     description: "The owner/repo GitHub target"
     required: false
@@ -42,6 +45,7 @@ runs:
       shell: bash -eux {0}
       run: |
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
+        export PERSONAL_ACCESS_TOKEN=${{ inputs.personal_access_token }}
         export GITHUB_ACTOR=${{ github.triggering_actor }}
         export RH_REPOSITORY=${{ inputs.target }}
         export RH_DRY_RUN=${{ inputs.dry_run }}

--- a/.github/actions/install-releaser/action.yml
+++ b/.github/actions/install-releaser/action.yml
@@ -10,5 +10,5 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
+            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
         fi

--- a/.github/actions/install-releaser/action.yml
+++ b/.github/actions/install-releaser/action.yml
@@ -6,4 +6,5 @@ runs:
     - shell: bash
       id: install-releaser
       run: |
-        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh

--- a/.github/actions/install-releaser/action.yml
+++ b/.github/actions/install-releaser/action.yml
@@ -7,8 +7,10 @@ runs:
       id: install-releaser
       run: |
         set -eux
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
+        # Install Jupyter Releaser if it is not already installed
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
+            cd "${{ github.action_path }}"
+            cd ../../..
+            pip install -e .
         fi

--- a/.github/actions/install-releaser/action.yml
+++ b/.github/actions/install-releaser/action.yml
@@ -6,11 +6,4 @@ runs:
     - shell: bash
       id: install-releaser
       run: |
-        set -eux
-        # Install Jupyter Releaser if it is not already installed
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            cd "${{ github.action_path }}"
-            cd ../../..
-            pip install -e .
-        fi
+        bash "${{ github.action_path }}"/../scripts/install-releaser.sh

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -35,11 +35,9 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pwd
-            ls
-            ls ..
-            ls ../..; true
-            pip install -q git+https://github.com/blink1073/jupyter_releaser.git@use-pr-for-changes
+            cd "${{ github.action_path }}"
+            cd ../../..
+            pip install -e .
         fi
 
     - id: populate-release

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -32,7 +32,8 @@ runs:
     - name: install-releaser
       shell: bash
       run: |
-        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: populate-release
       shell: bash -eux {0}

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -29,7 +29,10 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: ../install-releaser
+    - name: install-releaser
+      run: |
+        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
+
     - id: populate-release
       shell: bash -eux {0}
       run: |

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: "GitHub access token"
     required: true
+  personal_access_token:
+    description: "GitHub PAT used to create pull requests"
+    required: false
   target:
     description: "The owner/repo GitHub target"
     required: false
@@ -39,6 +42,7 @@ runs:
       shell: bash -eux {0}
       run: |
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
+        export PERSONAL_ACCESS_TOKEN=${{ inputs.personal_access_token }}
         export GITHUB_ACTOR=${{ github.triggering_actor }}
         export RH_REPOSITORY=${{ inputs.target }}
         export RH_DRY_RUN=${{ inputs.dry_run }}

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -30,6 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
+      shell: bash
       run: |
         bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -29,18 +29,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
-      run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        echo "environment? ${{job.environment}}"
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            cd "${{ github.action_path }}"
-            cd ../../..
-            pip install -e .
-        fi
-
+    - uses: ../install-releaser
     - id: populate-release
       shell: bash -eux {0}
       run: |

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -33,6 +33,7 @@ runs:
       shell: bash -eux {0}
       run: |
         # Install Jupyter Releaser from git unless we are testing Releaser itself
+        echo "environment? ${{job.environment}}"
         if ! command -v jupyter-releaser &> /dev/null
         then
             cd "${{ github.action_path }}"

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -34,7 +34,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: ../install-releaser
+    - name: install-releaser
+      run: |
+        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -41,8 +41,12 @@ runs:
         if ! command -v jupyter-releaser &> /dev/null
         then
             echo "hi"
-            echo "${{ github.action_repository}}"
-            echo "${{ github.action_path }}"
+            cd "${{ github.action_path }}"
+            pwd
+            cd ..
+            ls
+            cd ..
+            ls
             pip install -q git+https://github.com/.git@
         fi
 

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -37,19 +37,12 @@ runs:
     - name: install-releaser
       shell: bash -eux {0}
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
+        # Install Jupyter Releaser if it is not already installed
         if ! command -v jupyter-releaser &> /dev/null
         then
-            echo "hi"
             cd "${{ github.action_path }}"
-            pwd
-            cd ..
-            ls
-            cd ..
-            ls
-            cd ..
-            ls
-            pip install -q git+https://github.com/.git@
+            cd ../../..
+            pip install -e .
         fi
 
     - id: prep-release

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -42,7 +42,7 @@ runs:
         then
             echo "hi"
             echo "${{ github.action_repository}}"
-            echo "${{ github.action_ref }}"
+            echo "${{ github.action_path }}"
             pip install -q git+https://github.com/.git@
         fi
 

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -37,7 +37,8 @@ runs:
     - name: install-releaser
       shell: bash
       run: |
-        bash "${{ github.action_path }}"/../scripts/install-releaser.sh
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -34,16 +34,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
-      run: |
-        # Install Jupyter Releaser if it is not already installed
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            cd "${{ github.action_path }}"
-            cd ../../..
-            pip install -e .
-        fi
+    - uses: ../install-releaser
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -35,6 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
+      shell: bash
       run: |
         bash "${{ github.action_path }}"/../scripts/install-releaser.sh
 

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -40,7 +40,10 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
+            echo "hi"
+            echo "${{ github.action_repository}}"
+            echo "${{ github.action_ref }}"
+            pip install -q git+https://github.com/.git@
         fi
 
     - id: prep-release

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -40,11 +40,7 @@ runs:
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
         then
-            pwd
-            ls
-            ls ..
-            ls ../..; true
-            pip install -q git+https://github.com/blink1073/jupyter_releaser.git@use-pr-for-changes
+            pip install -q git+https://github.com/${{ github.action_repository}}.git@${{ github.action_ref }}
         fi
 
     - id: prep-release

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -47,6 +47,8 @@ runs:
             ls
             cd ..
             ls
+            cd ..
+            ls
             pip install -q git+https://github.com/.git@
         fi
 

--- a/.github/scripts/bump_tag.sh
+++ b/.github/scripts/bump_tag.sh
@@ -1,7 +1,7 @@
 set -eux
 
-# Update the v1 tag for GitHub Actions consumers
+# Update the stable tag for GitHub Actions consumers
 if [[ ${RH_DRY_RUN:=true} != 'true' ]]; then
-    git tag -f -a v2 -m "Github Action release"
+    git tag -f -a v3 -m "Github Action release"
     git push origin -f --tags
 fi

--- a/.github/scripts/install-releaser.sh
+++ b/.github/scripts/install-releaser.sh
@@ -1,0 +1,10 @@
+set -eux
+# Install Jupyter Releaser if it is not already installed
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if ! command -v jupyter-releaser &> /dev/null
+then
+    cd "${SCRIPT_DIR}/../.."
+    pip install -e .
+fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,12 +19,7 @@ jobs:
   publish_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Install Dependencies
-        shell: bash
-        run: |
-          pip install -e .
       - name: Populate Release
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,12 @@ jobs:
   publish_release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          pip install -e .
       - name: Populate Release
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,6 @@ jobs:
       - coverage
       - docs
       - lint
-      - check_local_actions
       - test_minimum_versions
       - test_prereleases
       - generate_changelog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,32 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - run: hatch run docs:build
 
+  check_local_actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: prep-release
+        uses: ./.github/actions/prep-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
+
+      - name: populate-release
+        uses: ./.github/actions/populate-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release_url: ${{ steps.prep-release.outputs.release_url }}
+          dry_run: true
+
+      - name: publish-release
+        uses: ./.github/actions/finalize-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
+          dry_run: true
+
   check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:
@@ -133,6 +159,7 @@ jobs:
       - coverage
       - docs
       - lint
+      - check_local_actions
       - test_minimum_versions
       - test_prereleases
       - generate_changelog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,32 +126,6 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - run: hatch run docs:build
 
-  check_local_actions:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: prep-release
-        uses: ./.github/actions/prep-release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: true
-
-      - name: populate-release
-        uses: ./.github/actions/populate-release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release_url: ${{ steps.prep-release.outputs.release_url }}
-          dry_run: true
-
-      - name: publish-release
-        uses: ./.github/actions/finalize-release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release_url: ${{ steps.populate-release.outputs.release_url }}
-          dry_run: true
-
   check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -128,8 +128,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Local git checkout
+# Local git checkouts
 .jupyter_releaser_checkout
+.jupyter_release_bare_repo
 
 # macOS
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,12 @@ To run the Python tests, use:
 ```bash
 pytest
 ```
+
+## End to End Verification Testing
+
+If you're making substantial changes, you may want to test the release workflow
+on a test repo that uses `TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/`.
+
+Update the actions on that repo to point to your releaser fork and branch, e.g.
+
+`uses: blink1073/jupyter_releaser/.github/actions/populate-release@use-pr-for-changes`

--- a/docs/source/background/theory.md
+++ b/docs/source/background/theory.md
@@ -46,12 +46,12 @@ Detailed workflows are available to draft a changelog, draft a release, publish 
   - Builds tarball(s) using `npm pack`
   - Make sure tarball(s) can be installed and imported in a new npm package
 - Adds a commit that includes the hashes of the dist files
-- Creates an annotated version tag in standard format
 - If given, bumps the version using the post version spec. he post version
   spec can also be given as a setting, [Write Releaser Config Guide](../how_to_guides/write_config.md).
 - Verifies that the SHA of the most recent commit has not changed on the target
   branch, preventing a mismatch of release commit.
-- Pushes the commits and tag to the target `branch`
+- Creates a Pull Request with the release and optional post version commit and
+  automatically merges the PR.
 - Pusehes the created assets to the draft release, along with an `asset_shas.json` file capturing the checksums of the files.
 
 ### Finalize Release Action
@@ -61,6 +61,7 @@ Detailed workflows are available to draft a changelog, draft a release, publish 
 - Downloads the dist assets from the release
 - Verifies shas of release assets against the `asset_shas.json` file.
 - Publishes assets to appropriate registries.
+- Creates an annotated version tag in standard format and pushes to the remote.
 - Publishes the final GitHub release
 - If the tag is on a backport branch, makes a forwardport PR for the changelog entry
 

--- a/docs/source/get_started/making_release_from_releaser.md
+++ b/docs/source/get_started/making_release_from_releaser.md
@@ -18,7 +18,7 @@ already uses Jupyter Releaser.
 
 - Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
   - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
-    _environment_ should be left blank.
+    _environment_ should be set to the release environment configured on PyPI.
 - Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
 
 </details>

--- a/docs/source/get_started/making_release_from_releaser.md
+++ b/docs/source/get_started/making_release_from_releaser.md
@@ -12,6 +12,11 @@ already uses Jupyter Releaser.
 
 - Fork `jupyter_releaser`
 
+- Generate a [GitHub Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions.  You must use a classic
+  token since it will need writes to multiple repositories.
+
+- Add the token as `PERSONAL_ACCESS_TOKEN` in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) of your fork. The token must have `repo` and `workflow` scopes.
+
 - Set up PyPI:
 
 <details><summary>Using PyPI trusted publisher (modern way)</summary>

--- a/docs/source/get_started/making_release_from_releaser.md
+++ b/docs/source/get_started/making_release_from_releaser.md
@@ -12,11 +12,16 @@ already uses Jupyter Releaser.
 
 - Fork `jupyter_releaser`
 
-- Generate a [GitHub Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions
-
-- Add the token as `ADMIN_GITHUB_TOKEN` in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) of your fork. The token must have `repo` and `workflow` scopes.
-
 - Set up PyPI:
+
+<details><summary>Using PyPI trusted publisher (modern way)</summary>
+
+- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+  - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
+    _environment_ should be left blank.
+- Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
+
+</details>
 
 <details><summary>Using PyPI token (legacy way)</summary>
 
@@ -37,15 +42,6 @@ already uses Jupyter Releaser.
     owner1/repo1/path/to/package1,token1
     owner1/repo1/path/to/package2,token2
     ```
-
-</details>
-
-<details><summary>Using PyPI trusted publisher (modern way)</summary>
-
-- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
-  - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
-    _environment_ should be left blank.
-- Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
 
 </details>
 

--- a/docs/source/get_started/making_release_from_repo.md
+++ b/docs/source/get_started/making_release_from_repo.md
@@ -5,8 +5,9 @@ already uses Jupyter Releaser using workflows on its own repository.
 
 ## Prerequisites
 
-- Admin write access to the target repository
-- Previously set up GitHub Actions secrets for PyPI and/or NPM
+- Access to run the workflow, and approve deployments in the environment
+  if applicable.
+- Previously set up GitHub Actions secrets for PERSONAL_ACCESS_TOKEN, PYPI_TOKEN (if not using trusted publishers) and/or NPM_TOKEN.
 
 ## Prep Release
 

--- a/docs/source/how_to_guides/convert_repo_from_releaser.md
+++ b/docs/source/how_to_guides/convert_repo_from_releaser.md
@@ -8,6 +8,7 @@ See checklist below for details:
 
 - Markdown changelog
 - Bump version configuration (if using Python), for example [tbump](https://github.com/dmerejkowsky/tbump)
+- [Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions.
 - Access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github)
 - If needed, access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens).
 
@@ -18,7 +19,7 @@ A. Prep the `jupyter_releaser` fork:
 - [ ] Clone this repository onto your GitHub user account.
 
 - [ ] Add a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with access to target GitHub repo to run
-  GitHub Actions, saved as `ADMIN_GITHUB_TOKEN` in the
+  GitHub Actions, saved as `PERSONAL_ACCESS_TOKEN` in the
   [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
   The token will need "public_repo", and "repo:status" permissions.
 

--- a/docs/source/how_to_guides/convert_repo_from_releaser.md
+++ b/docs/source/how_to_guides/convert_repo_from_releaser.md
@@ -8,7 +8,6 @@ See checklist below for details:
 
 - Markdown changelog
 - Bump version configuration (if using Python), for example [tbump](https://github.com/dmerejkowsky/tbump)
-- [Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions.
 - Access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github)
 - If needed, access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens).
 
@@ -47,7 +46,7 @@ A. Prep the `jupyter_releaser` fork:
 
 <details><summary>Using PyPI trusted publisher (modern way)</summary>
 
-- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) pointing to your releaser fork repository and release workflow file.
   - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
     _environment_ should be left blank.
 - Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))

--- a/docs/source/how_to_guides/convert_repo_from_repo.md
+++ b/docs/source/how_to_guides/convert_repo_from_repo.md
@@ -8,22 +8,12 @@ See checklist below for details:
 
 - Markdown changelog
 - Bump version configuration (if using Python), for example [hatch](https://hatch.pypa.io/latest/)
-- [Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions.
 - Set up:
   - \[_modern way_\] [Add a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to your PyPI project
   - \[_legacy way_\] Access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github)
 - If needed, access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens).
 
 ## Checklist for Adoption
-
-- [ ] Add a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), preferably from a "machine user" GitHub
-  account that has admin access to the repository. The token itself will
-  need "public_repo", and "repo:status" permissions. Save the token as
-  `ADMIN_GITHUB_TOKEN`
-  in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository). We need this
-  access token to allow for branch protection rules, which block the pushing
-  of commits when using the `GITHUB_TOKEN`, even when run from an admin user
-  account.
 
 - [ ] Set up PyPI:
 

--- a/docs/source/how_to_guides/convert_repo_from_repo.md
+++ b/docs/source/how_to_guides/convert_repo_from_repo.md
@@ -8,12 +8,24 @@ See checklist below for details:
 
 - Markdown changelog
 - Bump version configuration (if using Python), for example [hatch](https://hatch.pypa.io/latest/)
+- [Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions.
 - Set up:
   - \[_modern way_\] [Add a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to your PyPI project
   - \[_legacy way_\] Access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github)
 - If needed, access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens).
 
 ## Checklist for Adoption
+
+- [ ] Add a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), preferably a fine-grained personal access token. For fine-grained personal tokens, the org must be configured to allow them.  The org should "Require administrator approval" for fine-grained tokens.  We need this
+  access token to allow the workflows to run when a pull request is
+  created by the action.
+  The fine-grained token should have the org as its
+  "Resource owner" and have "Pull Request: Read and Write" permissions
+  on the target repository. The token will have to have an expiration, but can be regenerated in the UI.  Save the token as
+  `PERSONAL_ACCESS_TOKEN`
+  in the [Environment secrets](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets) for the environment used in the release workflow, which is "release" in the default template.  There is no need to store the token anywhere
+  else, since it is only used for this purpose and can be re-generated
+  when expired.
 
 - [ ] Set up PyPI:
 

--- a/docs/source/how_to_guides/convert_repo_from_repo.md
+++ b/docs/source/how_to_guides/convert_repo_from_repo.md
@@ -17,21 +17,21 @@ See checklist below for details:
 
 - [ ] Set up PyPI:
 
+<details><summary>Using PyPI trusted publisher (modern way)</summary>
+
+- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+  - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
+    _environment_ should match the GitHub environment used in the PyPI trusted publisher setup.
+- Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
+
+</details>
+
 <details><summary>Using PyPI token (legacy way)</summary>
 
 - Add access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github) stored as `PYPI_TOKEN`.
   _Note_ For security reasons, it is recommended that you scope the access
   to a single repository. Additionally, this token should belong to a
   machine account and not a user account.
-
-</details>
-
-<details><summary>Using PyPI trusted publisher (modern way)</summary>
-
-- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
-  - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
-    _environment_ should be left blank.
-- Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
 
 </details>
 

--- a/example-workflows/full-release.yml
+++ b/example-workflows/full-release.yml
@@ -25,6 +25,9 @@ on:
 jobs:
   full_release:
     runs-on: ubuntu-latest
+    # The use of an environment is important for security, and required if you
+    # use PyPI trusted publisher.
+    environment: release
     permissions:
       # This is useful if you want to use PyPI trusted publisher
       # and NPM provenance
@@ -36,7 +39,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}
@@ -47,7 +50,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ steps.prep-release.outputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -62,7 +65,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: "** Next Step **"

--- a/example-workflows/prep-release.yml
+++ b/example-workflows/prep-release.yml
@@ -29,7 +29,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}

--- a/example-workflows/publish-release.yml
+++ b/example-workflows/publish-release.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    # The use of an environment is important for security, and required if you
+    # use PyPI trusted publisher.
+    environment: release
     permissions:
       # This is useful if you want to use PyPI trusted publisher
       # and NPM provenance
@@ -26,7 +29,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -41,7 +44,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: "** Next Step **"

--- a/example-workflows/publish-release.yml
+++ b/example-workflows/publish-release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          personal_access_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -45,6 +46,7 @@ jobs:
         uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          personal_access_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: "** Next Step **"

--- a/jupyter_releaser/actions/finalize_release.py
+++ b/jupyter_releaser/actions/finalize_release.py
@@ -15,7 +15,8 @@ if release_url:
 run_action("jupyter-releaser publish-assets")
 
 if release_url:
-    run_action("jupyter-releaser prep-git")
+    if not bool(os.environ.get('RH_DRY_RUN', False)):
+        run_action("jupyter-releaser prep-git")
     run_action("jupyter-releaser tag-release")
     run_action("jupyter-releaser forwardport-changelog")
     run_action("jupyter-releaser publish-release")

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -526,16 +526,7 @@ def check_npm(dist_dir, npm_install_options):
     help="Whether to skip tagging npm workspace packages",
 )
 @use_checkout_dir()
-def tag_release(
-    ref,
-    branch,
-    repo,
-    dist_dir,
-    tag_format,
-    tag_message,
-    no_git_tag_workspace,
-    dry_run,
-):
+def tag_release(ref, branch, repo, dist_dir, tag_format, tag_message, no_git_tag_workspace):
     """Create release commit and tag"""
     lib.tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace)
 

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -507,9 +507,6 @@ def check_npm(dist_dir, npm_install_options):
 @add_options(branch_options)
 @add_options(dist_dir_options)
 @click.option(
-    "--release-commit", envvar="RH_RELEASE_COMMIT", default="", help="The release commit sha"
-)
-@click.option(
     "--tag-format",
     envvar="RH_TAG_FORMAT",
     default="v{version}",
@@ -533,16 +530,13 @@ def tag_release(
     branch,
     repo,
     dist_dir,
-    release_commit,
     tag_format,
     tag_message,
     no_git_tag_workspace,
     dry_run,
 ):
     """Create release commit and tag"""
-    lib.tag_release(
-        branch, dist_dir, release_commit, tag_format, tag_message, no_git_tag_workspace, dry_run
-    )
+    lib.tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace, dry_run)
 
 
 @main.command()

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -232,7 +232,9 @@ dry_run_options: t.Any = [
 ]
 
 
-git_url_options: t.Any = [click.option("--git-url", help="A custom url for the git repository")]
+git_url_options: t.Any = [
+    click.option("--git-url", envvar="RH_GIT_URL", help="A custom url for the git repository")
+]
 
 
 release_url_options: t.Any = [

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -525,7 +525,6 @@ def check_npm(dist_dir, npm_install_options):
     is_flag=True,
     help="Whether to skip tagging npm workspace packages",
 )
-@add_options(dry_run_options)
 @use_checkout_dir()
 def tag_release(
     ref,
@@ -538,7 +537,7 @@ def tag_release(
     dry_run,
 ):
     """Create release commit and tag"""
-    lib.tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace, dry_run)
+    lib.tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace)
 
 
 @main.command()

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -166,7 +166,9 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR')
-    pull = gh.pulls.create(title, head, base, body, maintainer_can_modify, False, None)
+    pat = os.environ.get('PERSONAL_ACCESS_TOKEN', auth)
+    gh_pull = util.get_gh_object(dry_run=dry_run, owner=owner, repo=repo_name, token=pat)
+    pull = gh_pull.pulls.create(title, head, base, body, maintainer_can_modify, False, None)
     util.log(f'Created a PR: {pull.number}')
 
     # Try to add the documentation label to the PR.

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -516,8 +516,8 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         util.run(f"{util.GIT_FETCH_CMD} {branch}")
         checkout_cmd = f"git checkout {branch}"
 
-    util.run('git log -n 5')
     if checkout_exists:
+        util.run('git log -n 5')
         try:
             util.run(f"git checkout {branch}")
         except Exception:
@@ -525,7 +525,8 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
     else:
         util.run(checkout_cmd)
 
-    util.run('git log -n 5')
+    if checkout_exists:
+        util.run('git log -n 5')
 
     # Check for detached head state, create branch if needed
     try:

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -134,11 +134,12 @@ def make_pr_branch(branch, prefix, dry_run=False):
     """Make a new branch with a uuid suffix."""
     pr_branch = f"{prefix}-{uuid.uuid1().hex}"
     dirty = util.run("git --no-pager diff --stat") != ""
+    remote = util.get_remote_name(dry_run)
     if dirty:
         util.run("git stash")
     if not dry_run:
         util.run(f"{util.GIT_FETCH_CMD} {branch}")
-    util.run(f"git checkout -b {pr_branch} origin/{branch}")
+    util.run(f"git checkout -b {pr_branch} {remote}/{branch}")
     if dirty:
         util.run("git stash apply")
 
@@ -605,7 +606,8 @@ def forwardport_changelog(auth, ref, branch, repo, username, changelog_path, dry
         raise ValueError(msg)
 
     # Check out the branch again
-    util.run(f"git checkout -B {branch} origin/{branch}")
+    remote = util.get_remote_name(dry_run)
+    util.run(f"git checkout -B {branch} {remote}/{branch}")
 
     default_entry = changelog.extract_current(changelog_path)
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -483,7 +483,9 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
     orig_dir = os.getcwd()
     os.chdir(checkout_dir)
 
-    if not url:
+    local_git = url is not None
+
+    if not local_git:
         if auth:
             url = f"https://{username}:{auth}@github.com/{repo}.git"
         else:
@@ -509,7 +511,7 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         ref = None
 
     # Reuse existing branch if possible
-    if ref:
+    if ref and not local_git:
         util.run(f"{util.GIT_FETCH_CMD} +{ref}:{ref_alias}")
         util.run(f"{util.GIT_FETCH_CMD} {ref}")
         checkout_cmd = f"git checkout -B {branch} {ref_alias}"

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -187,6 +187,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
         gh.pulls.merge(number, title, commit_message, sha, "rebase")
 
         if dry_run:
+            util.run(f"git fetch origin {branch}")
             util.run(f"git checkout {branch}")
             util.run(f"git merge --ff-only {pr_branch}")
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -213,7 +213,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
             }
             """
             variables = {"pullRequestId": pull.id, "mergeMethod": "rebase"}
-            headers = {"Authorization": auth}
+            headers = {"Authorization": f"Bearer {auth}", 'X-Github-Next-Global-ID': '1'}
             request = requests.post(
                 'https://api.github.com/graphql',
                 json={'query': query, 'variables': variables},

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -157,7 +157,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     head = pr_branch
     maintainer_can_modify = True
 
-    remote = util.get_remote_name()
+    remote = util.get_remote_name(dry_run)
 
     util.run(f"git push {remote} {pr_branch}")
 
@@ -198,7 +198,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace, dry_run):
     """Create release tag and push it"""
     # Get the branch commits.
-    remote_name = util.get_remote_name()
+    remote_name = util.get_remote_name(dry_run)
     util.run(f"git fetch {remote_name} {branch}")
 
     # Find the release commit.

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -159,7 +159,8 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     head = pr_branch
     maintainer_can_modify = True
 
-    util.run(f"git push origin {pr_branch}")
+    if not dry_run:
+        util.run(f"git push origin {pr_branch}")
 
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR"')
@@ -190,7 +191,8 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
             util.run(f"git merge --ff-only {pr_branch}")
 
         # Delete the remote branch if not dry run.
-        util.run(f"git push origin --delete {pr_branch}")
+        if not dry_run:
+            util.run(f"git push origin --delete {pr_branch}")
 
     util.actions_output("pr_url", pull.html_url)
 
@@ -222,7 +224,8 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
         npm.tag_workspace_packages()
 
     # Push the tag(s) to the remote.
-    util.run("git push origin --tags")
+    if not dry_run:
+        util.run("git push origin --tags")
 
     # Merge the tag into the source branch.
     util.run(f'git checkout {branch}')

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -476,7 +476,6 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
     checkout_exists = False
     if osp.exists(osp.join(checkout_dir, ".git")):
         util.log("Git checkout already exists")
-        util.run('git log -n 5')
         checkout_exists = True
 
     if not checkout_exists:
@@ -520,16 +519,12 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         checkout_cmd = f"git checkout {branch}"
 
     if checkout_exists:
-        util.run('git log -n 5')
         try:
             util.run(f"git checkout {branch}")
         except Exception:
             util.run(checkout_cmd)
     else:
         util.run(checkout_cmd)
-
-    if checkout_exists:
-        util.run('git log -n 5')
 
     # Check for detached head state, create branch if needed
     try:

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -159,9 +159,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     head = pr_branch
     maintainer_can_modify = True
 
-    remote = util.get_remote_name(dry_run)
-
-    util.run(f"git push {remote} {pr_branch}")
+    util.run(f"git push origin {pr_branch}")
 
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR"')
@@ -192,7 +190,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
             util.run(f"git merge --ff-only {pr_branch}")
 
         # Delete the remote branch if not dry run.
-        util.run(f"git push {remote} --delete {pr_branch}")
+        util.run(f"git push origin --delete {pr_branch}")
 
     util.actions_output("pr_url", pull.html_url)
 
@@ -607,8 +605,7 @@ def forwardport_changelog(auth, ref, branch, repo, username, changelog_path, dry
         raise ValueError(msg)
 
     # Check out the branch again
-    remote = util.get_remote_name(dry_run)
-    util.run(f"git checkout -B {branch} {remote}/{branch}")
+    util.run(f"git checkout -B {branch} origin/{branch}")
 
     default_entry = changelog.extract_current(changelog_path)
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -271,7 +271,7 @@ def populate_release(
     release = util.release_for_url(gh, release_url)
 
     # Create a release PR.
-    title = f"Release {version}"
+    title = f"[ci skip] Release {version}"
     body = title
     handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="release", dry_run=dry_run)
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -15,6 +15,7 @@ from glob import glob
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Type, Union
+from urllib.error import HTTPError
 
 import mdformat
 import requests
@@ -227,9 +228,11 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
             # Wait for the PR to be merged
             delay = 1
             for _ in range(10):
-                status = gh.pulls.check_if_merged(number)
-                if status == 204:  # noqa: PLR2004
-                    break
+                try:
+                    gh.pulls.check_if_merged(number)
+                except HTTPError as e:
+                    if e.code != 404:  # noqa: PLR2004
+                        raise
                 time.sleep(delay)
                 delay *= 2
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -187,7 +187,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 
         if dry_run:
             util.run(f"git checkout {branch}")
-            util.run(f"git merge --ff-only {pr_branch}")
+            util.run(f"git merge -X theirs {pr_branch}")
 
         # Delete the remote branch if not dry run.
         util.run(f"git push {remote} --delete {pr_branch}")

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -138,6 +138,8 @@ def make_pr_branch(branch, prefix, dry_run=False):
         util.run("git stash")
     if not dry_run:
         util.run(f"{util.GIT_FETCH_CMD} {branch}")
+    else:
+        util.run(f"git fetch origin {branch}")
     util.run(f"git checkout -b {pr_branch} origin/{branch}")
     if dirty:
         util.run("git stash apply")
@@ -187,7 +189,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 
         if dry_run:
             util.run(f"git checkout {branch}")
-            util.run(f"git merge -X theirs {pr_branch}")
+            util.run(f"git merge --ff-only {pr_branch}")
 
         # Delete the remote branch if not dry run.
         util.run(f"git push {remote} --delete {pr_branch}")

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -159,8 +159,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     head = pr_branch
     maintainer_can_modify = True
 
-    if not dry_run:
-        util.run(f"git push origin {pr_branch}")
+    util.run(f"git push origin {pr_branch}")
 
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR"')
@@ -187,13 +186,11 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
         gh.pulls.merge(number, title, commit_message, sha, "rebase")
 
         if dry_run:
-            util.run(f"git fetch origin {branch}")
             util.run(f"git checkout {branch}")
             util.run(f"git merge --ff-only {pr_branch}")
 
-        # Delete the remote branch if not dry run.
-        if not dry_run:
-            util.run(f"git push origin --delete {pr_branch}")
+        # Delete the remote branch.
+        util.run(f"git push origin --delete {pr_branch}")
 
     util.actions_output("pr_url", pull.html_url)
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -195,7 +195,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     util.actions_output("pr_url", pull.html_url)
 
 
-def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace, dry_run):
+def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace):
     """Create release tag and push it"""
     # Get the branch commits.
     util.run(f"git fetch origin {branch}")
@@ -222,8 +222,7 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
         npm.tag_workspace_packages()
 
     # Push the tag(s) to the remote.
-    if not dry_run:
-        util.run("git push origin --tags")
+    util.run("git push origin --tags")
 
     # Merge the tag into the source branch.
     util.run(f'git checkout {branch}')

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -167,6 +167,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR')
     pat = os.environ.get('PERSONAL_ACCESS_TOKEN', auth)
+    print('HELLO', len(pat), pat == auth)
     gh_pull = util.get_gh_object(dry_run=dry_run, owner=owner, repo=repo_name, token=pat)
     pull = gh_pull.pulls.create(title, head, base, body, maintainer_can_modify, False, None)
     util.log(f'Created a PR: {pull.number}')

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -218,8 +218,9 @@ def tag_release(
         util.run(f"git push {remote_name} --tags")
 
     # Merge the tag into the source branch.
-    util.run(f'git checkout {remote_name} {branch}')
-    util.run('git merge {tag_name}')
+    util.run(f"git fetch {remote_name} {branch}")
+    util.run(f'git checkout {branch}')
+    util.run(f'git merge {tag_name}')
 
 
 def populate_release(

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -473,6 +473,7 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
     checkout_exists = False
     if osp.exists(osp.join(checkout_dir, ".git")):
         util.log("Git checkout already exists")
+        util.run('git log -n 5')
         checkout_exists = True
 
     if not checkout_exists:
@@ -515,6 +516,7 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         util.run(f"{util.GIT_FETCH_CMD} {branch}")
         checkout_cmd = f"git checkout {branch}"
 
+    util.run('git log -n 5')
     if checkout_exists:
         try:
             util.run(f"git checkout {branch}")
@@ -522,6 +524,8 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
             util.run(checkout_cmd)
     else:
         util.run(checkout_cmd)
+
+    util.run('git log -n 5')
 
     # Check for detached head state, create branch if needed
     try:

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -217,6 +217,10 @@ def tag_release(
     if not os.path.exists(remote_url):
         util.run(f"git push {remote_name} --tags")
 
+    # Merge the tag into the source branch.
+    util.run(f'git checkout {remote_name} {branch}')
+    util.run('git merge {tag_name}')
+
 
 def populate_release(
     ref,
@@ -267,19 +271,6 @@ def populate_release(
 
     # Clean up after ourselves.
     util.run(f"git checkout {branch}")
-
-    # Set the body of the release with the changelog contents.
-    # Get the new release since the draft release might change urls.
-    util.log("Updating release")
-    release = gh.repos.update_release(
-        release.id,
-        release.tag_name,
-        release.target_commitish,
-        release.name,
-        body,
-        True,
-        release.prerelease,
-    )
 
     # Update the metadata to include the release commit.
     metadata = util.extract_metadata_from_release_url(gh, release.html_url, auth)

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -223,8 +223,9 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
         util.run(f"git push {remote_name} --tags")
 
     # Merge the tag into the source branch.
-    util.run(f'git checkout {branch}')
-    util.run(f'git merge {tag_name}')
+    if not dry_run:
+        util.run(f'git checkout {branch}')
+        util.run(f'git merge {tag_name}')
 
 
 def populate_release(

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -134,12 +134,11 @@ def make_pr_branch(branch, prefix, dry_run=False):
     """Make a new branch with a uuid suffix."""
     pr_branch = f"{prefix}-{uuid.uuid1().hex}"
     dirty = util.run("git --no-pager diff --stat") != ""
-    remote = util.get_remote_name(dry_run)
     if dirty:
         util.run("git stash")
     if not dry_run:
         util.run(f"{util.GIT_FETCH_CMD} {branch}")
-    util.run(f"git checkout -b {pr_branch} {remote}/{branch}")
+    util.run(f"git checkout -b {pr_branch} origin/{branch}")
     if dirty:
         util.run("git stash apply")
 
@@ -199,8 +198,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace, dry_run):
     """Create release tag and push it"""
     # Get the branch commits.
-    remote_name = util.get_remote_name(dry_run)
-    util.run(f"git fetch {remote_name} {branch}")
+    util.run(f"git fetch origin {branch}")
 
     # Find the release commit.
     commit_message = util.run("git log --format=%B -n 1 HEAD")
@@ -224,7 +222,7 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
         npm.tag_workspace_packages()
 
     # Push the tag(s) to the remote.
-    util.run(f"git push {remote_name} --tags")
+    util.run("git push origin --tags")
 
     # Merge the tag into the source branch.
     util.run(f'git checkout {branch}')
@@ -588,6 +586,7 @@ def forwardport_changelog(auth, ref, branch, repo, username, changelog_path, dry
         return
 
     # Get the entry for the tag
+    util.run(f"git fetch origin {tag}")
     util.run(f"git checkout {tag}")
     entry = changelog.extract_current(changelog_path)
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -166,7 +166,6 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR')
     pat = os.environ.get('PERSONAL_ACCESS_TOKEN', auth)
-    print('HELLO', len(pat), pat == auth)
     gh_pull = util.get_gh_object(dry_run=dry_run, owner=owner, repo=repo_name, token=pat)
     pull = gh_pull.pulls.create(title, head, base, body, maintainer_can_modify, False, None)
     util.log(f'Created a PR: {pull.number}')

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -256,7 +256,6 @@ def populate_release(
 
     # Create the release commit.
     util.create_release_commit(version, release_message, dist_dir)
-    release_commit = util.run('git rev-parse HEAD')
 
     # Bump to post version if given.
     if post_version_spec:
@@ -277,25 +276,8 @@ def populate_release(
     # Clean up after ourselves.
     util.run(f"git checkout {branch}")
 
-    # Update the metadata to include the release commit.
-    metadata = util.extract_metadata_from_release_url(gh, release.html_url, auth)
-    metadata['release_commit'] = release_commit
-
-    # Delete the old metadata file
-    for item in gh.repos.list_release_assets(release.id):
-        if item.name == 'metadata.json':
-            gh.repos.delete_release_asset(item.id)
-            break
-
-    with tempfile.TemporaryDirectory() as d:
-        metadata_path = Path(d) / util.METADATA_JSON
-        with open(metadata_path, "w") as fid:
-            json.dump(metadata, fid)
-
-        assets.append(metadata_path)
-
-        # Upload the assets to the draft release.
-        release = util.upload_assets(gh, assets, release, auth)
+    # Upload the assets to the draft release.
+    release = util.upload_assets(gh, assets, release, auth)
 
     # Set the GitHub action output
     util.actions_output("release_url", release.html_url)

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -187,7 +187,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 
         if dry_run:
             util.run(f"git checkout {branch}")
-            util.run(f"git merge {pr_branch}")
+            util.run(f"git merge --ff-only {pr_branch}")
 
         # Delete the remote branch if not dry run.
         util.run(f"git push {remote} --delete {pr_branch}")

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -201,7 +201,9 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
                     util.log(f"Merge attempt {i} of 10")
                     gh.pulls.merge(number, title, commit_message, sha, "rebase")
                 except HTTPError as e:
-                    if e.code != 404:  # noqa: PLR2004
+                    # This code will be raised when required checks have not
+                    # passed.
+                    if e.code != 405:  # noqa: PLR2004
                         raise
                 time.sleep(delay)
                 delay *= 2

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -195,7 +195,8 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
     """Create release tag and push it"""
     # Get the branch commits.
     remote_name = util.get_remote_name(dry_run)
-    util.run(f"git fetch {remote_name} {branch}")
+    if not dry_run:
+        util.run(f"git fetch {remote_name} {branch}")
 
     # Find the release commit.
     commit_message = util.run("git log --format=%B -n 1 HEAD")
@@ -531,7 +532,7 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         util.run(f"git switch -c {branch}")
 
     try:
-        has_git_config = util.run("git config user.email").strip()
+        has_git_config = bool(util.run("git config user.email").strip())
     except Exception:
         has_git_config = False
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -131,7 +131,7 @@ def draft_changelog(
 
 
 def make_pr_branch(branch, prefix, dry_run=False):
-    # Make a new branch with a uuid suffix
+    """Make a new branch with a uuid suffix."""
     pr_branch = f"{prefix}-{uuid.uuid1().hex}"
     dirty = util.run("git --no-pager diff --stat") != ""
     if dirty:
@@ -195,12 +195,12 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
     """Create release tag and push it"""
     # Get the branch commits.
     remote_name = util.get_remote_name(dry_run)
-    if not dry_run:
-        util.run(f"git fetch {remote_name} {branch}")
+    util.run(f"git fetch {remote_name} {branch}")
 
     # Find the release commit.
     commit_message = util.run("git log --format=%B -n 1 HEAD")
     if "SHA256 hashes:" not in commit_message:
+        util.run('git stash')
         util.run('git checkout HEAD~1')
     commit_message = util.run("git log --format=%B -n 1 HEAD")
     if "SHA256 hashes:" not in commit_message:
@@ -219,14 +219,11 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
         npm.tag_workspace_packages()
 
     # Push the tag(s) to the remote.
-    remote_url = util.run(f"git config --get remote.{remote_name}.url")
-    if not os.path.exists(remote_url):
-        util.run(f"git push {remote_name} --tags")
+    util.run(f"git push {remote_name} --tags")
 
     # Merge the tag into the source branch.
-    if not dry_run:
-        util.run(f'git checkout {branch}')
-        util.run(f'git merge {tag_name}')
+    util.run(f'git checkout {branch}')
+    util.run(f'git merge {tag_name}')
 
 
 def populate_release(

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -200,6 +200,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
                 try:
                     util.log(f"Merge attempt {i} of 10")
                     gh.pulls.merge(number, title, commit_message, sha, "rebase")
+                    break
                 except HTTPError as e:
                     # This code will be raised when required checks have not
                     # passed.

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -82,12 +82,12 @@ def draft_changelog(
 
     # Check out all changed files.
     try:
-        util.run("git checkout .", echo=True)
+        util.run("git checkout .")
     except CalledProcessError as e:
         util.log(str(e))
         return
 
-    util.run("git status", echo=True)
+    util.run("git status")
     util.log(f"\n\nCreating draft GitHub release for {version}")
     owner, repo_name = repo.split("/")
     gh = util.get_gh_object(dry_run=dry_run, owner=owner, repo=repo_name, token=auth)
@@ -158,7 +158,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
     maintainer_can_modify = True
 
     if not dry_run:
-        util.run(f"git push origin {pr_branch}", echo=True)
+        util.run(f"git push origin {pr_branch}")
 
     # title, head, base, body, maintainer_can_modify, draft, issue
     util.log('Creating a PR"')
@@ -186,7 +186,7 @@ def handle_pr(auth, branch, pr_branch, repo, title, body, pr_type="forwardport",
 
         # Delete the remote branch
         if not dry_run:
-            util.run(f"git push origin --delete {pr_branch}", echo=True)
+            util.run(f"git push origin --delete {pr_branch}")
 
     util.actions_output("pr_url", pull.html_url)
 
@@ -195,7 +195,8 @@ def tag_release(branch, dist_dir, tag_format, tag_message, no_git_tag_workspace,
     """Create release tag and push it"""
     # Get the branch commits.
     remote_name = util.get_remote_name(dry_run)
-    util.run(f"git fetch {remote_name} {branch}")
+    if not dry_run:
+        util.run(f"git fetch {remote_name} {branch}")
 
     # Find the release commit.
     commit_message = util.run("git log --format=%B -n 1 HEAD")
@@ -421,12 +422,12 @@ def publish_assets(  # noqa
                 env["TWINE_PASSWORD"] = twine_token
                 # NOTE: Do not print the env since a twine token extracted from
                 # a PYPI_TOKEN_MAP will not be sanitized in output
-                util.retry(f"{twine_cmd} {name}", cwd=dist_dir, env=env, echo=True)
+                util.retry(f"{twine_cmd} {name}", cwd=dist_dir, env=env)
                 found = True
         elif suffix == ".tgz":
             # Ignore already published versions
             try:
-                util.run(f"{npm_cmd} {name}", cwd=dist_dir, quiet=True, quiet_error=True, echo=True)
+                util.run(f"{npm_cmd} {name}", cwd=dist_dir, quiet=True, quiet_error=True)
             except CalledProcessError as e:
                 stderr = e.stderr
                 if "EPUBLISHCONFLICT" in stderr or "previously published versions" in stderr:
@@ -537,8 +538,8 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         # Default to the GitHub Actions bot
         # https://github.community/t/github-actions-bot-email-address/17204/6
         git_user_name = username or "41898282+github-actions[bot]"
-        util.run(f'git config user.email "{git_user_name}@users.noreply.github.com"', echo=True)
-        util.run(f'git config user.name "{git_user_name}"', echo=True)
+        util.run(f'git config user.email "{git_user_name}@users.noreply.github.com"')
+        util.run(f'git config user.name "{git_user_name}"')
 
     os.chdir(orig_dir)
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -476,7 +476,7 @@ def prep_git(ref, branch, repo, auth, username, url):  # noqa
         checkout_exists = True
 
     if not checkout_exists:
-        util.run(f"git init {checkout_dir}")
+        util.run(f"git init -b main {checkout_dir}")
 
     orig_dir = os.getcwd()
     os.chdir(checkout_dir)

--- a/jupyter_releaser/mock_github.py
+++ b/jupyter_releaser/mock_github.py
@@ -242,6 +242,12 @@ def create_a_pull_request(owner: str, repo: str) -> PullRequest:
     return pull
 
 
+@app.put("/repos/{owner}/{repo}/pulls/{pull_number}/merge")
+def merge_pull_request(owner: str, repo: str, pull_number: int) -> None:
+    del pulls[str(pull_number)]
+    write_to_file("pulls", pulls)
+
+
 @app.post("/repos/{owner}/{repo}/issues/{issue_number}/labels")
 def add_labels_to_an_issue(owner: str, repo: str, issue_number: int) -> BaseModel:
     """https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue"""

--- a/jupyter_releaser/mock_github.py
+++ b/jupyter_releaser/mock_github.py
@@ -244,6 +244,7 @@ def create_a_pull_request(owner: str, repo: str) -> PullRequest:
 
 @app.put("/repos/{owner}/{repo}/pulls/{pull_number}/merge")
 def merge_pull_request(owner: str, repo: str, pull_number: int) -> None:
+    """https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request"""
     del pulls[str(pull_number)]
     write_to_file("pulls", pulls)
 

--- a/jupyter_releaser/tests/conftest.py
+++ b/jupyter_releaser/tests/conftest.py
@@ -46,7 +46,7 @@ def git_repo(tmp_path):
     prev_dir = os.getcwd()
     os.chdir(tmp_path)
 
-    run("git init")
+    run("git init -b main")
     run("git config user.name snuffy")
     run("git config user.email snuffy@sesame.com")
 

--- a/jupyter_releaser/tests/conftest.py
+++ b/jupyter_releaser/tests/conftest.py
@@ -45,11 +45,9 @@ def mock_env(mocker):
 def git_repo(tmp_path):
     prev_dir = os.getcwd()
     os.chdir(tmp_path)
-
     run("git init -b main")
     run("git config user.name snuffy")
     run("git config user.email snuffy@sesame.com")
-
     run("git checkout -b foo")
     gitignore = tmp_path / ".gitignore"
     gitignore.write_text(f"dist/*\nbuild/*\n{util.CHECKOUT_NAME}\n", encoding="utf-8")

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -105,8 +105,8 @@ def test_prep_git_full(py_package, tmp_path, mocker, runner):
             call("git checkout -B foo refs/pull/42"),
             call("git symbolic-ref -q HEAD"),
             call("git config user.email"),
-            call('git config user.email "snuffy@users.noreply.github.com"', echo=True),
-            call('git config user.name "snuffy"', echo=True),
+            call('git config user.email "snuffy@users.noreply.github.com"'),
+            call('git config user.name "snuffy"'),
         ]
     )
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -149,6 +149,7 @@ check-imports: RH_CHECK_IMPORTS
 dist-dir: RH_DIST_DIR
 dry-run: RH_DRY_RUN
 expected-sha: RH_EXPECTED_SHA
+git-url: RH_GIT_URL
 npm-cmd: RH_NPM_COMMAND
 npm-install-options: RH_NPM_INSTALL_OPTIONS
 npm-registry: NPM_REGISTRY

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -467,7 +467,7 @@ def test_populate_release_dry_run(py_dist, mocker, runner, git_prep, draft_relea
     )
 
     log = get_log()
-    assert "before-populate-release" not in log
+    assert "before-populate-release" in log
     assert "after-populate-release" in log
 
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -834,14 +834,16 @@ def test_ensure_sha(npm_package, runner, git_prep):
         runner(["ensure-sha", "--branch", current, "--expected-sha", "abc"])
 
 
-def test_end_to_end(npm_package, runner, mocker, mock_github, git_repo):
-    os.environ["GITHUB_ACTIONS"] = "true"
+def test_end_to_end(npm_package, runner, mocker):
     os.environ["RH_DRY_RUN"] = "true"
+    os.environ["GITHUB_REPOSITORY"] = "test/test"
+    current = util.run("git branch --show-current", cwd=npm_package)
+    os.environ["RH_BRANCH"] = os.environ["RH_REF"] = current
+
+    util.prepare_environment(False)
 
     # prep release
-    runner(["prep-git", "--git-url", git_repo])
-    current = util.run("git branch --show-current", cwd=util.CHECKOUT_NAME)
-    os.environ['RH_BRANCH'] = current
+    runner(["prep-git"])
     # includes bump_version
     mock_changelog_entry(npm_package, runner, mocker)
     runner(["build-changelog"])
@@ -857,7 +859,7 @@ def test_end_to_end(npm_package, runner, mocker, mock_github, git_repo):
     os.environ["RH_RELEASE_URL"] = release_url
 
     # populate release
-    runner(["prep-git", "--git-url", git_repo])
+    runner(["prep-git"])
     runner(["ensure-sha"])
     runner(["bump-version"])
     runner(["extract-changelog"])

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -837,7 +837,7 @@ def test_ensure_sha(npm_package, runner, git_prep):
 
 def test_end_to_end(npm_package, runner, mocker):
     os.environ["RH_DRY_RUN"] = "true"
-    os.environ["GITHUB_REPOSITORY"] = "test/test"
+    os.environ["RH_REPOSITORY"] = "test/test"
     current = util.run("git branch --show-current", cwd=npm_package)
     os.environ["RH_BRANCH"] = os.environ["RH_REF"] = current
 

--- a/jupyter_releaser/tests/test_cli.py
+++ b/jupyter_releaser/tests/test_cli.py
@@ -97,7 +97,7 @@ def test_prep_git_full(py_package, tmp_path, mocker, runner):
     mock_run.assert_has_calls(
         [
             call("echo before-prep-git >> 'log.txt'"),
-            call("git init .jupyter_releaser_checkout"),
+            call("git init -b main .jupyter_releaser_checkout"),
             call("git remote add origin https://snuffy:abc123@github.com/baz/bar.git"),
             call(f"{GIT_FETCH_CMD} --tags --force"),
             call(f"{GIT_FETCH_CMD} +refs/pull/42:refs/pull/42"),

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -590,6 +590,7 @@ def prepare_environment(fetch_draft_release=True):  # noqa
             ref = os.environ["GITHUB_REF"]
             log(f"Using GITHUB_REF: {ref}")
             os.environ["RH_BRANCH"] = "/".join(ref.split("/")[2:])
+    branch = os.environ["RH_BRANCH"]
 
     # For a dry run, set up a bare repo to use as the origin.
     if dry_run:
@@ -600,7 +601,6 @@ def prepare_environment(fetch_draft_release=True):  # noqa
         if not os.path.exists(bare_repo):
             run(f"git init -b main --bare {url}")
             run(f"git remote add test {url}")
-            branch = os.environ['RH_BRANCH']
             run(f"git fetch origin {branch}")
             run(f"git checkout {branch}")
             run(f"git push test {branch}")
@@ -616,7 +616,6 @@ def prepare_environment(fetch_draft_release=True):  # noqa
         ensure_mock_github()
 
     # Set up GitHub object.
-    branch = os.environ.get("RH_BRANCH")
     log(f"Getting GitHub connection for {os.environ['RH_REPOSITORY']}")
     owner, repo_name = os.environ["RH_REPOSITORY"].split("/")
     auth = os.environ.get("GITHUB_ACCESS_TOKEN", "")

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -684,7 +684,7 @@ def get_remote_name(dry_run):
     tfile = tempfile.NamedTemporaryFile(suffix=".git")
     tfile.close()
     _local_remote = tfile.name.replace(os.sep, "/")
-    run(f"git init --bare {_local_remote}")
+    run(f"git init -b main --bare {_local_remote}")
     run(f"git remote add test {_local_remote}")
     return "test"
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -671,7 +671,7 @@ _local_remote = None
 def get_remote_name(dry_run):
     """Get the appropriate remote git name."""
     global _local_remote  # noqa
-    remotes = run('git remote')
+    remotes = run('git remote').splitlines()
 
     if not dry_run:
         return remotes[0]

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -645,7 +645,7 @@ def handle_since() -> str:
 def ensure_sha(dry_run, expected_sha, branch):
     """Ensure the sha of the remote branch matches the expected sha"""
     log("Ensuring sha...")
-    remote_name = get_remote_name(False)
+    remote_name = get_remote_name()
     run("git remote -v", echo=True)
     run(f"git fetch {remote_name} {branch}", echo=True)
     sha = run(f"git rev-parse {remote_name}/{branch}", echo=True)
@@ -665,10 +665,7 @@ def get_gh_object(dry_run=False, **kwargs):
     return core.GhApi(**kwargs)
 
 
-_local_remote = None
-
-
-def get_remote_name(dry_run):
+def get_remote_name():
     """Get the appropriate remote git name."""
     remotes = run('git remote')
     return remotes.splitlines()[0]

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -348,7 +348,7 @@ def bump_version(version_spec, *, changelog_path="", version_cmd=""):  # noqa
                 version_spec = f"{v.major}.{v.minor + 1}.0"
 
     # Bump the version
-    run(f"{version_cmd} {version_spec}", echo=True)
+    run(f"{version_cmd} {version_spec}")
 
     return get_version()
 
@@ -646,9 +646,9 @@ def ensure_sha(dry_run, expected_sha, branch):
     """Ensure the sha of the remote branch matches the expected sha"""
     log("Ensuring sha...")
     remote_name = get_remote_name(False)
-    run("git remote -v", echo=True)
-    run(f"git fetch {remote_name} {branch}", echo=True)
-    sha = run(f"git rev-parse {remote_name}/{branch}", echo=True)
+    run("git remote -v")
+    run(f"git fetch {remote_name} {branch}")
+    sha = run(f"git rev-parse {remote_name}/{branch}")
     if sha != expected_sha:
         msg = f"{branch} current sha {sha} is not equal to expected sha {expected_sha}"
         if dry_run:

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -602,7 +602,8 @@ def prepare_environment(fetch_draft_release=True):  # noqa
         if not os.path.exists(bare_repo):
             run(f"git init -b main --bare {url}")
             run(f"git remote add test {url}")
-            run(f"git fetch origin --unshallow {branch}")
+            if 'GITHUB_REPOSITORY' in os.environ:
+                run(f"git fetch origin --unshallow {branch}")
             run(f"git checkout {branch}")
             run(f"git push test {branch}")
         os.environ["RH_GIT_URL"] = url

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -409,11 +409,11 @@ def actions_output(name, value):
 def get_latest_tag(source, since_last_stable=False):
     """Get the default 'since' value for a branch"""
     source = source or get_branch()
-    tags = run(f"git --no-pager tag --sort=-creatordate --merged {source}", quiet=True)
-    if not tags:
+    resp = run(f"git --no-pager tag --sort=-creatordate --merged {source}", quiet=True)
+    if not resp:
         return ""
 
-    tags = tags.splitlines()
+    tags = resp.splitlines()
 
     if since_last_stable:
         stable_tag = re.compile(r"\d\.\d\.\d$")

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -580,7 +580,8 @@ def prepare_environment(fetch_draft_release=True):  # noqa
     dry_run = os.environ.get("RH_DRY_RUN", "").lower() == "true"
 
     # Set the branch when using check release.
-    if not os.environ.get("RH_BRANCH") and dry_run:
+    branch = os.environ.get("RH_BRANCH", "")
+    if not branch and dry_run:
         if os.environ.get("GITHUB_BASE_REF"):
             base_ref = os.environ.get("GITHUB_BASE_REF", "")
             log(f"Using GITHUB_BASE_REF: ${base_ref}")
@@ -590,7 +591,7 @@ def prepare_environment(fetch_draft_release=True):  # noqa
             ref = os.environ["GITHUB_REF"]
             log(f"Using GITHUB_REF: {ref}")
             os.environ["RH_BRANCH"] = "/".join(ref.split("/")[2:])
-    branch = os.environ["RH_BRANCH"]
+        branch = os.environ["RH_BRANCH"]
 
     # For a dry run, set up a bare repo to use as the origin.
     if dry_run:

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -691,7 +691,6 @@ def get_remote_name(dry_run):
     _local_remote = tfile.name.replace(os.sep, "/")
     run(f"git init -b main --bare {_local_remote}")
     run(f"git remote add test {_local_remote}")
-    run(f"git push {_local_remote} main")
     return "test"
 
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -602,7 +602,7 @@ def prepare_environment(fetch_draft_release=True):  # noqa
         if not os.path.exists(bare_repo):
             run(f"git init -b main --bare {url}")
             run(f"git remote add test {url}")
-            run(f"git fetch origin {branch}")
+            run(f"git fetch origin --unshallow {branch}")
             run(f"git checkout {branch}")
             run(f"git push test {branch}")
         os.environ["RH_GIT_URL"] = url

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -686,6 +686,7 @@ def get_remote_name(dry_run):
     _local_remote = tfile.name.replace(os.sep, "/")
     run(f"git init -b main --bare {_local_remote}")
     run(f"git remote add test {_local_remote}")
+    run(f"git push {_local_remote} main")
     return "test"
 
 

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -19,6 +19,7 @@ from glob import glob
 from io import BytesIO
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, check_output
+from typing import Any
 from urllib.parse import urlparse
 
 import requests
@@ -61,7 +62,7 @@ GH_ID_TOKEN_URL_VAR = "ACTIONS_ID_TOKEN_REQUEST_URL"  # noqa
 GH_ID_TOKEN_TOKEN_VAR = "ACTIONS_ID_TOKEN_REQUEST_TOKEN"  # noqa
 
 
-def run(cmd, **kwargs):
+def run(cmd: str, **kwargs: Any) -> str:
     """Run a command as a subprocess and get the output as a string"""
     quiet_error = kwargs.pop("quiet_error", False)
     show_cwd = kwargs.pop("show_cwd", False)
@@ -94,7 +95,7 @@ def run(cmd, **kwargs):
         raise e
 
 
-def _run_win(cmd, **kwargs):
+def _run_win(cmd: str, **kwargs: Any) -> str:
     """Run a command as a subprocess and get the output as a string"""
     quiet = kwargs.pop("quiet", False)
 
@@ -124,6 +125,7 @@ def _run_win(cmd, **kwargs):
         log("stdout:\n", e.output.strip(), "\n\n")
         if check:
             raise e
+        return ''
 
 
 def log(*outputs, **kwargs):

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -671,7 +671,7 @@ _local_remote = None
 def get_remote_name(dry_run):
     """Get the appropriate remote git name."""
     remotes = run('git remote')
-    return remotes[0]
+    return remotes.splitlines()[0]
 
 
 def get_mock_github_url():

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -560,7 +560,7 @@ def extract_metadata_from_release_url(gh, release_url, auth):
     return data
 
 
-def prepare_environment(fetch_draft_release=True):  # noqa
+def prepare_environment(fetch_draft_release=True):
     """Prepare the environment variables, for use when running one of the
     action scripts."""
     # Set up env variables
@@ -602,21 +602,6 @@ def prepare_environment(fetch_draft_release=True):  # noqa
     owner, repo_name = os.environ["RH_REPOSITORY"].split("/")
     auth = os.environ.get("GITHUB_ACCESS_TOKEN", "")
     gh = get_gh_object(dry_run=dry_run, owner=owner, repo=repo_name, token=auth)
-
-    # Ensure the user is an admin.
-    if not dry_run:
-        user = os.environ["GITHUB_ACTOR"]
-        log(f"Getting permission level for {user}")
-        try:
-            collab_level = gh.repos.get_collaborator_permission_level(user)
-            if collab_level["permission"] != "admin":
-                msg = f"User {user} does not have admin permission"
-                raise RuntimeError(msg)
-            log("User was admin!")
-        except Exception as e:
-            log(str(e))
-            msg = "Could not get user permission level, assuming user was not admin!"
-            raise RuntimeError(msg) from None
 
     # Get the latest draft release if none is given.
     release_url = os.environ.get("RH_RELEASE_URL")

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -670,24 +670,8 @@ _local_remote = None
 
 def get_remote_name(dry_run):
     """Get the appropriate remote git name."""
-    global _local_remote  # noqa
-    if not dry_run:
-        return "origin"
-
-    if _local_remote:
-        try:
-            run(f"git remote add test {_local_remote}")
-        except Exception:  # noqa
-            pass
-        return "test"
-
-    tfile = tempfile.NamedTemporaryFile(suffix=".git")
-    tfile.close()
-    _local_remote = tfile.name.replace(os.sep, "/")
-    run(f"git init -b main --bare {_local_remote}")
-    run(f"git remote add test {_local_remote}")
-    run(f"git push {_local_remote} main")
-    return "test"
+    remotes = run('git remote')
+    return remotes[0]
 
 
 def get_mock_github_url():

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -67,7 +67,7 @@ def run(cmd: str, **kwargs: Any) -> str:
     quiet_error = kwargs.pop("quiet_error", False)
     show_cwd = kwargs.pop("show_cwd", False)
     quiet = kwargs.get("quiet", False)
-    echo = kwargs.pop("echo", False)
+    echo = kwargs.pop("echo", True)
 
     if echo:
         prefix = "COMMAND"


### PR DESCRIPTION
Fixes #505

- Remove the need for `ADMIN_GITHUB_TOKEN`
- Create a PR and merge it to make the actual changes in populate release
- Create and push the tag as part of finalize release
- Steps:
  - [x] Test this using https://github.com/blink1073/test-python-project
  - [x] Get tests to pass
  - [x] Add notes on how to test changes - use the fork and branch as the `@`
  - [x] Update examples and docs - must always use environment for security - should use trusted publishers
  - [x] Publish this as the v3 tag
  - [x] Update docs and example workflows for the new fine-grained token access
