### PR TITLE
Add test for repository.url

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -183,7 +183,7 @@ version_cmd_options: t.Any = [
     click.option("--version-cmd", envvar="RH_VERSION_COMMAND", help="The version command")
 ]
 
-repo_options: t.Any  = [
+repo_options: t.Any = [
     click.option("--repo", envvar="RH_REPOSITORY", help="The git repo"),
 ]
 

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -183,12 +183,14 @@ version_cmd_options: t.Any = [
     click.option("--version-cmd", envvar="RH_VERSION_COMMAND", help="The version command")
 ]
 
+repo_options: t.Any  = [
+    click.option("--repo", envvar="RH_REPOSITORY", help="The git repo"),
+]
 
 branch_options: t.Any = [
     click.option("--ref", envvar="RH_REF", help="The source reference"),
     click.option("--branch", envvar="RH_BRANCH", help="The target branch"),
-    click.option("--repo", envvar="RH_REPOSITORY", help="The git repo"),
-]
+] + repo_options
 
 auth_options: t.Any = [
     click.option("--auth", envvar="GITHUB_ACCESS_TOKEN", help="The GitHub auth token"),
@@ -512,13 +514,14 @@ def build_npm(package, dist_dir):
 @main.command()
 @add_options(dist_dir_options)
 @add_options(npm_install_options)
+@add_options(repo_options)
 @use_checkout_dir()
-def check_npm(dist_dir, npm_install_options):
+def check_npm(dist_dir, npm_install_options, repo):
     """Check npm package"""
     if not osp.exists("./package.json"):
         util.log("Skipping check-npm since there is no package.json file")
         return
-    npm.check_dist(dist_dir, npm_install_options)
+    npm.check_dist(dist_dir, npm_install_options, repo)
 
 
 @main.command()

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -187,7 +187,7 @@ repo_options: t.Any = [
     click.option("--repo", envvar="RH_REPOSITORY", help="The git repo"),
 ]
 
-branch_options: t.Any = [
+branch_options: t.Any = [  # noqa: RUF005
     click.option("--ref", envvar="RH_REF", help="The source reference"),
     click.option("--branch", envvar="RH_BRANCH", help="The target branch"),
 ] + repo_options

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -76,9 +76,8 @@ def extract_dist(dist_dir, target, repo=""):
             if url.endswith(".git"):
                 url = url[:-4]
             if not url.endswith(repo):
-                raise ValueError(
-                    f"package.json for '{name}' does not define a 'repository.url' matching the cloned repository '{repo}'."
-                )
+                msg = f"package.json for '{name}' does not define a 'repository.url' matching the cloned repository '{repo}'."
+                raise ValueError(msg)
 
         # Skip if it is a private package
         if data.get("private", False):  # pragma: no cover

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -71,7 +71,7 @@ def extract_dist(dist_dir, target, repo=""):
         data = extract_package(path)
         name = data["name"]
 
-        if repo:
+        if repo and os.name != "nt":
             url = data.get("repository", {}).get("url", "")
             if url.endswith(".git"):
                 url = url[:-4]

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -57,8 +57,8 @@ def build_dist(package, dist_dir):
 
 def extract_dist(dist_dir, target, repo=""):
     """Extract dist files from a dist_dir into a target dir
-    
-    
+
+
     If `repo` is provided, check that the repository URL is ending by it.
     """
     names = []

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -55,8 +55,12 @@ def build_dist(package, dist_dir):
             )
 
 
-def extract_dist(dist_dir, target):
-    """Extract dist files from a dist_dir into a target dir"""
+def extract_dist(dist_dir, target, repo=""):
+    """Extract dist files from a dist_dir into a target dir
+    
+    
+    If `repo` is provided, check that the repository URL is ending by it.
+    """
     names = []
     paths = sorted(glob(f"{dist_dir}/*.tgz"))
     util.log(f"Extracting {len(paths)} packages...")
@@ -66,6 +70,15 @@ def extract_dist(dist_dir, target):
 
         data = extract_package(path)
         name = data["name"]
+
+        if repo:
+            url = data.get("repository", {}).get("url", "")
+            if url.endswith(".git"):
+                url = url[:-4]
+            if not url.endswith(repo):
+                raise ValueError(
+                    f"package.json for '{name}' does not define a 'repository.url' matching the cloned repository '{repo}'."
+                )
 
         # Skip if it is a private package
         if data.get("private", False):  # pragma: no cover
@@ -93,14 +106,16 @@ def extract_dist(dist_dir, target):
     return names
 
 
-def check_dist(dist_dir, install_options):
+def check_dist(dist_dir, install_options, repo):
     """Check npm dist file(s) in a dist dir"""
+    repo = repo or util.get_repo()
+
     with TemporaryDirectory() as td:
         util.run("npm init -y", cwd=td, quiet=True)
         names = []
         staging = Path(td) / "staging"
 
-        names = extract_dist(dist_dir, staging)
+        names = extract_dist(dist_dir, staging, repo)
 
         install_str = " ".join(f"./staging/{name}" for name in names)
 

--- a/jupyter_releaser/tests/conftest.py
+++ b/jupyter_releaser/tests/conftest.py
@@ -112,12 +112,19 @@ def workspace_package(npm_package):
             sub_data = json.loads(pkg_json.read_text(encoding="utf-8"))
             sub_data["dependencies"] = dict(bar="*")
             sub_data["main"] = "index.js"
+            sub_data["repository"] = dict(url=str(npm_package))
             pkg_json.write_text(json.dumps(sub_data), encoding="utf-8")
         elif name == "baz":
             pkg_json = new_dir / "package.json"
             sub_data = json.loads(pkg_json.read_text(encoding="utf-8"))
             sub_data["dependencies"] = dict(foo="*")
             sub_data["main"] = "index.js"
+            sub_data["repository"] = dict(url=str(npm_package))
+            pkg_json.write_text(json.dumps(sub_data), encoding="utf-8")
+        elif name == "bar":
+            pkg_json = new_dir / "package.json"
+            sub_data = json.loads(pkg_json.read_text(encoding="utf-8"))
+            sub_data["repository"] = dict(url=str(npm_package))
             pkg_json.write_text(json.dumps(sub_data), encoding="utf-8")
     os.chdir(prev_dir)
     util.run("git add .")

--- a/jupyter_releaser/tests/util.py
+++ b/jupyter_releaser/tests/util.py
@@ -1,5 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import json
 import os
 import shutil
 import tempfile
@@ -177,6 +178,14 @@ def mock_changelog_entry(package_path, runner, mocker, version_spec=VERSION_SPEC
 def create_npm_package(git_repo):
     npm = util.normalize_path(shutil.which("npm"))
     run(f"{npm} init -y")
+
+    # Add the npm provenance info.
+    pack_json = Path(git_repo / "package.json")
+    with pack_json.open() as fid:
+        data = json.load(fid)
+    data["repository"] = dict(url=str(git_repo))
+    with pack_json.open("w") as fid:
+        json.dump(data, fid)
 
     git_repo.joinpath("index.js").write_text('console.log("hello");\n', encoding="utf-8")
 


### PR DESCRIPTION
When publishing JupyterLab with the NPM provenance feature, it failed because the package.json file was not defining a proper `repository.url`. This adds a test for it in `check-npm-dist`