### PR TITLE
Fix string repository

### DIFF
--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -72,7 +72,11 @@ def extract_dist(dist_dir, target, repo=""):
         name = data["name"]
 
         if repo and os.name != "nt":
-            url = data.get("repository", {}).get("url", "")
+            data_repository = data.get("repository", {})
+            if isinstance(data_repository, str):
+                url = data_repository
+            else:
+                url = data_repository.get("url", "")
             if url.endswith(".git"):
                 url = url[:-4]
             if not url.endswith(repo):


### PR DESCRIPTION
### Reference

Bug seen in https://github.com/jupyterlab/lumino/actions/runs/7170712609/job/19524081611?pr=664

The buildutils package of lumino defines its repository as a string (this is [valid](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository))
https://github.com/jupyterlab/lumino/blob/744b258922173ca80bb6ec9718732ff437ebf75b/buildutils/package.json#L10

### Code changes

Test for the type of _repository_