### PR TITLE
Reduce usage of admin token

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -14,14 +14,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash -eux {0}
+    - shell: bash
       id: install-releaser
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
-        fi
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -32,14 +32,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
+    - shell: bash
+      id: install-releaser
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
-        fi
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: finalize-release
       shell: bash -eux {0}

--- a/.github/actions/install-releaser/action.yml
+++ b/.github/actions/install-releaser/action.yml
@@ -6,9 +6,5 @@ runs:
     - shell: bash
       id: install-releaser
       run: |
-        set -eux
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
-        fi
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -4,6 +4,8 @@ inputs:
   token:
     description: "GitHub access token"
     required: true
+  personal_access_token:
+    description: "An admin Github access token used to push the changes"
   target:
     description: "The owner/repo GitHub target"
     required: false
@@ -48,6 +50,7 @@ runs:
         export RH_STEPS_TO_SKIP=${{ inputs.steps_to_skip }}
         export RH_RELEASE_URL=${{ inputs.release_url }}
         export RH_BRANCH=${{ inputs.branch }}
+        export RH_PERSONAL_ACCESS_TOKEN=${{ inputs.personal_access_token }}
         python -m jupyter_releaser.actions.populate_release
 
     - if: ${{ failure() }}

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -6,6 +6,7 @@ inputs:
     required: true
   personal_access_token:
     description: "An admin Github access token used to push the changes"
+    required: true
   target:
     description: "The owner/repo GitHub target"
     required: false
@@ -31,14 +32,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
+    - shell: bash
+      id: install-releaser
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
-        fi
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: populate-release
       shell: bash -eux {0}

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -38,14 +38,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
+    - shell: bash
+      id: install-releaser
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
-        fi
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: prep-release
       shell: bash -eux {0}

--- a/.github/actions/publish-changelog/action.yml
+++ b/.github/actions/publish-changelog/action.yml
@@ -21,14 +21,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: install-releaser
-      shell: bash -eux {0}
+    - shell: bash
+      id: install-releaser
       run: |
-        # Install Jupyter Releaser from git unless we are testing Releaser itself
-        if ! command -v jupyter-releaser &> /dev/null
-        then
-            pip install -q git+https://github.com/jupyter-server/jupyter_releaser.git@v2
-        fi
+        cd "${{ github.action_path }}/../../scripts"
+        bash install-releaser.sh
 
     - id: publish-changelog
       shell: bash -eux {0}

--- a/.github/scripts/install-releaser.sh
+++ b/.github/scripts/install-releaser.sh
@@ -1,0 +1,10 @@
+set -eux
+# Install Jupyter Releaser if it is not already installed
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if ! command -v jupyter-releaser &> /dev/null
+then
+    cd "${SCRIPT_DIR}/../.."
+    pip install -e .
+fi

--- a/.github/workflows/prep-self-release.yml
+++ b/.github/workflows/prep-self-release.yml
@@ -37,7 +37,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           target: jupyter-server/jupyter_releaser

--- a/.github/workflows/publish-self-release.yml
+++ b/.github/workflows/publish-self-release.yml
@@ -31,7 +31,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           target: jupyter-server/jupyter_releaser
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
@@ -43,7 +43,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ github.event.inputs.target }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 

--- a/docs/source/get_started/making_release_from_releaser.md
+++ b/docs/source/get_started/making_release_from_releaser.md
@@ -18,6 +18,15 @@ already uses Jupyter Releaser.
 
 - Set up PyPI:
 
+<details><summary>Using PyPI trusted publisher (modern way)</summary>
+
+- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
+  - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
+    _environment_ should be left blank.
+- Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
+
+</details>
+
 <details><summary>Using PyPI token (legacy way)</summary>
 
 - If the repo generates PyPI release(s), create a scoped PyPI [token](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github). We recommend using a scoped token for security reasons.
@@ -37,15 +46,6 @@ already uses Jupyter Releaser.
     owner1/repo1/path/to/package1,token1
     owner1/repo1/path/to/package2,token2
     ```
-
-</details>
-
-<details><summary>Using PyPI trusted publisher (modern way)</summary>
-
-- Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
-  - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
-    _environment_ should be left blank.
-- Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
 
 </details>
 

--- a/docs/source/how_to_guides/convert_repo_from_repo.md
+++ b/docs/source/how_to_guides/convert_repo_from_repo.md
@@ -22,7 +22,7 @@ See checklist below for details:
 
 - Set up your PyPI project by [adding a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
   - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
-    _environment_ should be left blank.
+    _environment_ should be kept as `release` (unless you choose a different name).
 - Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
 
 </details>
@@ -33,6 +33,8 @@ See checklist below for details:
   _Note_ For security reasons, it is recommended that you scope the access
   to a single repository. Additionally, this token should belong to a
   machine account and not a user account.
+- Additionally, you should still use a GitHub [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) to ensure write permissions
+  for the repo do not automatically grant release permissions.
 
 </details>
 
@@ -96,6 +98,10 @@ version_info = tuple(parts)
 - [ ] Update or add `RELEASE.md` that describes the onboarding and release process, e.g. [jupyter_server](https://github.com/jupyter-server/jupyter_server/blob/main/RELEASE.md).
 
 - [ ] Copy `prep-release.yml` and `publish-release.yml` from the `example-workflows` folder in this repository.
+
+- [ ] If you repo has required PR checks, you must either have a `.github/jupyterlab-probot.yml` file or add a `pr-ci-trigger` option to your `releaser`
+  configuration.  If using `jupyterlab-probot`, the config should be `@jupyterlab-probot, please restart ci`.  This config will cause releaser to
+  make the comment on the forwardport changelog PR or post-silent changelog PRs.
 
 - [ ] Optionally add configuration to the repository if non-standard options or hooks are needed.
 

--- a/docs/source/how_to_guides/convert_repo_from_repo.md
+++ b/docs/source/how_to_guides/convert_repo_from_repo.md
@@ -16,25 +16,7 @@ See checklist below for details:
 
 ## Checklist for Adoption
 
-- [ ] Add a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), preferably from a "machine user" GitHub
-  account that has admin access to the repository. The token itself will
-  need "public_repo", and "repo:status" permissions. Save the token as
-  `ADMIN_GITHUB_TOKEN`
-  in the [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository). We need this
-  access token to allow for branch protection rules, which block the pushing
-  of commits when using the `GITHUB_TOKEN`, even when run from an admin user
-  account.
-
 - [ ] Set up PyPI:
-
-<details><summary>Using PyPI token (legacy way)</summary>
-
-- Add access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github) stored as `PYPI_TOKEN`.
-  _Note_ For security reasons, it is recommended that you scope the access
-  to a single repository. Additionally, this token should belong to a
-  machine account and not a user account.
-
-</details>
 
 <details><summary>Using PyPI trusted publisher (modern way)</summary>
 
@@ -42,6 +24,15 @@ See checklist below for details:
   - if you use the example workflows, the _workflow name_ is `publish-release.yml` (or `full-release.yml`) and the
     _environment_ should be left blank.
 - Ensure the publish release job as `permissions`: `id-token : write` (see the [documentation](https://docs.pypi.org/trusted-publishers/using-a-publisher/))
+
+</details>
+
+<details><summary>Using PyPI token (legacy way)</summary>
+
+- Add access token for the [PyPI registry](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github) stored as `PYPI_TOKEN`.
+  _Note_ For security reasons, it is recommended that you scope the access
+  to a single repository. Additionally, this token should belong to a
+  machine account and not a user account.
 
 </details>
 

--- a/example-workflows/full-release.yml
+++ b/example-workflows/full-release.yml
@@ -29,10 +29,14 @@ on:
 jobs:
   full_release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       # This is useful if you want to use PyPI trusted publisher
       # and NPM provenance
       id-token: write
+      pull-requests: write
+      contents: write
+      issues: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -40,7 +44,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}
@@ -52,7 +56,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ steps.prep-release.outputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -67,7 +71,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: "** Next Step **"

--- a/example-workflows/prep-release.yml
+++ b/example-workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}

--- a/example-workflows/prep-release.yml
+++ b/example-workflows/prep-release.yml
@@ -26,6 +26,9 @@ on:
 jobs:
   prep_release:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 

--- a/example-workflows/publish-changelog.yml
+++ b/example-workflows/publish-changelog.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   publish_changelog:
+    permissions:
+      pull-requests: write
+      contents: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -18,7 +22,7 @@ jobs:
         id: publish-changelog
         uses: jupyter-server/jupyter_releaser/.github/actions/publish-changelog@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
 
       - name: "** Next Step **"

--- a/example-workflows/publish-release.yml
+++ b/example-workflows/publish-release.yml
@@ -15,10 +15,13 @@ on:
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       # This is useful if you want to use PyPI trusted publisher
       # and NPM provenance
       id-token: write
+      pull-requests: write
+      contents: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -26,7 +29,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -41,7 +44,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: "** Next Step **"

--- a/example-workflows/publish-release.yml
+++ b/example-workflows/publish-release.yml
@@ -22,6 +22,7 @@ jobs:
       id-token: write
       pull-requests: write
       contents: write
+      issues: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -222,7 +222,6 @@ pr_ci_trigger_options: t.Any = [
         "--pr-ci-trigger",
         envvar="RH_PR_CI_TRIGGER",
         default="",
-        multiple=True,
         help="The comment used to restart CI on a PR that is opened using a GitHub workflow token.",
     )
 ]

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -217,6 +217,16 @@ python_packages_options: t.Any = [
     )
 ]
 
+pr_ci_trigger_options: t.Any = [
+    click.option(
+        "--pr-ci-trigger",
+        envvar="RH_PR_CI_TRIGGER",
+        default="",
+        multiple=True,
+        help="The comment used to restart CI on a trigger that is opened using a GitHub workflow token.",
+    )
+]
+
 check_imports_options: t.Any = [
     click.option(
         "--check-imports",
@@ -718,11 +728,22 @@ def ensure_sha(ref, branch, repo, dry_run, expected_sha):  # noqa: ARG001
 @add_options(changelog_path_options)
 @add_options(dry_run_options)
 @add_options(release_url_options)
+@add_options(pr_ci_trigger_options)
 @use_checkout_dir()
-def forwardport_changelog(auth, ref, branch, repo, username, changelog_path, dry_run, release_url):
+def forwardport_changelog(
+    auth,
+    ref,  # noqa: ARG001
+    branch,
+    repo,
+    username,  # noqa: ARG001
+    changelog_path,
+    dry_run,
+    release_url,
+    pr_ci_trigger,
+):
     """Forwardport Changelog Entries to the Default Branch"""
     lib.forwardport_changelog(
-        auth, ref, branch, repo, username, changelog_path, dry_run, release_url
+        auth, branch, repo, changelog_path, dry_run, release_url, pr_ci_trigger
     )
 
 
@@ -730,11 +751,12 @@ def forwardport_changelog(auth, ref, branch, repo, username, changelog_path, dry
 @add_options(auth_options)
 @add_options(branch_options)
 @add_options(changelog_path_options)
+@add_options(pr_ci_trigger_options)
 @add_options(dry_run_options)
 @use_checkout_dir()
-def publish_changelog(auth, ref, branch, repo, changelog_path, dry_run):  # noqa: ARG001
+def publish_changelog(auth, ref, branch, repo, changelog_path, pr_ci_trigger, dry_run):  # noqa: ARG001
     """Remove changelog placeholder entries."""
-    lib.publish_changelog(branch, repo, auth, changelog_path, dry_run)
+    lib.publish_changelog(branch, repo, auth, changelog_path, pr_ci_trigger, dry_run)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -194,6 +194,14 @@ auth_options: t.Any = [
     click.option("--auth", envvar="GITHUB_ACCESS_TOKEN", help="The GitHub auth token"),
 ]
 
+admin_auth_options: t.Any = [
+    click.option(
+        "--personal-access-token",
+        envvar="RH_PERSONAL_ACCESS_TOKEN",
+        help="The admin GitHub personal access token",
+    ),
+]
+
 username_options: t.Any = [
     click.option("--username", envvar="GITHUB_ACTOR", help="The git username")
 ]
@@ -560,6 +568,8 @@ def tag_release(dist_dir, release_message, tag_format, tag_message, no_git_tag_w
 @add_options(branch_options)
 @add_options(version_cmd_options)
 @add_options(auth_options)
+@add_options(admin_auth_options)
+@add_options(username_options)
 @add_options(changelog_path_options)
 @add_options(dist_dir_options)
 @add_options(dry_run_options)
@@ -575,6 +585,8 @@ def populate_release(
     repo,
     version_cmd,
     auth,
+    personal_access_token,
+    username,
     changelog_path,
     dist_dir,
     dry_run,
@@ -592,6 +604,8 @@ def populate_release(
         repo,
         version_cmd,
         auth,
+        personal_access_token,
+        username,
         changelog_path,
         dist_dir,
         dry_run,

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -223,7 +223,7 @@ pr_ci_trigger_options: t.Any = [
         envvar="RH_PR_CI_TRIGGER",
         default="",
         multiple=True,
-        help="The comment used to restart CI on a trigger that is opened using a GitHub workflow token.",
+        help="The comment used to restart CI on a PR that is opened using a GitHub workflow token.",
     )
 ]
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -249,6 +249,8 @@ def populate_release(
     repo,  # noqa: ARG001
     version_cmd,
     auth,
+    personal_access_token,
+    username,
     changelog_path,
     dist_dir,
     dry_run,
@@ -286,6 +288,13 @@ def populate_release(
     remote_name = util.get_remote_name(dry_run)
     remote_url = util.run(f"git config --get remote.{remote_name}.url")
     if not os.path.exists(remote_url):
+        if personal_access_token:
+            remote_name = "admin_origin"
+            admin_url = (
+                f"https://{username}:{personal_access_token}@github.com/{owner}/{repo_name}.git"
+            )
+            util.run(f"git remote add {remote_name} {admin_url}")
+
         util.run(f"git push {remote_name} HEAD:{branch} --follow-tags --tags")
 
     # Set the body of the release with the changelog contents.

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -16,9 +16,9 @@ from subprocess import CalledProcessError
 from typing import Type, Union
 
 import mdformat
+import yaml
 from packaging.version import parse as parse_version
 from pkginfo import SDist, Wheel
-from ruamel.yaml import YAML
 
 from jupyter_releaser import changelog, npm, python, util
 
@@ -199,9 +199,8 @@ def make_changelog_pr(
     if not pr_ci_trigger:
         probot_config = Path("./.github/jupyterlab-probot.yml")
         if probot_config.exists():
-            text = probot_config.read_text("utf-8")
-            yaml = YAML(typ="safe")
-            data = yaml.load(text)
+            with probot_config.open() as fid:
+                data = yaml.safe_load(fid)
             name = data.get("botUser", "jupyterlab-bot")
             pr_ci_trigger = f"@{name}, please restart ci"
     if pr_ci_trigger:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pkginfo",
     "pypiserver",
     "pipx",
-    "ruamel.yaml",
+    "pyyaml",
     "requests",
     "requests_cache",
     "toml~=0.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pkginfo",
     "pypiserver",
     "pipx",
+    "ruamel.yaml",
     "requests",
     "requests_cache",
     "toml~=0.10",
@@ -59,8 +60,7 @@ test = [
   "pytest>=7.0",
   "pytest-mock",
   "pytest-xdist[psutil]",
-  "uvicorn",
-  "ruamel.yaml"
+  "uvicorn"
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,6 +166,7 @@ npm-tag: NPM_TAG
 npm-token: NPM_TOKEN
 post-version-message: RH_POST_VERSION_MESSAGE
 post-version-spec: RH_POST_VERSION_SPEC
+pr-ci-trigger: RH_PR_CI_TRIGGER
 pydist-check-cmd: RH_PYDIST_CHECK_CMD
 pydist-extra-check-cmds: RH_EXTRA_PYDIST_CHECK_CMDS
 pydist-resource-paths: RH_PYDIST_RESOURCE_PATHS

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,8 +6,8 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import yaml
 from ghapi.core import GhApi
-from ruamel.yaml import YAML
 
 from jupyter_releaser import changelog, cli, util
 from jupyter_releaser.util import run
@@ -224,8 +224,7 @@ def create_python_package(git_repo, multi=False, not_matching_name=False):
         text = here.parent.joinpath(".pre-commit-config.yaml").read_text(encoding="utf-8")
 
         # Remove sp-repo-review and don't check yaml files.
-        yaml = YAML(typ="safe")
-        table = yaml.load(text)
+        table = yaml.safe_load(text)
         for item in list(table["repos"]):
             if item["repo"] == "https://github.com/scientific-python/cookie":
                 table["repos"].remove(item)


### PR DESCRIPTION
- [x] Add a separate personal_access_token that is only used for the direct push to the target branch, otherwise use the user's token.
- [ ] Add docs that recommend the use of a fine-grained access token in an environment for `publish_release`
- [ ] Add test for pr ci trigger and personal access token
- [ ] Test against a scratch repo