### PR TITLE
Allow customizing the shell for the action

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -11,10 +11,14 @@ inputs:
   steps_to_skip:
     description: "Comma separated list of steps to skip"
     required: false
+  shell:
+    description: "The shell being used for the action steps"
+    required: false
+    default: bash -eux {0}
 runs:
   using: "composite"
   steps:
-    - shell: bash -eux {0}
+    - shell: ${{ inputs.shell }}
       id: install-releaser
       run: |
         # Install Jupyter Releaser from git unless we are testing Releaser itself
@@ -24,7 +28,7 @@ runs:
         fi
 
     - id: prep-release
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export RH_DRY_RUN="true"
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
@@ -33,7 +37,7 @@ runs:
         python -m jupyter_releaser.actions.prep_release
 
     - id: populate-release
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export RH_DRY_RUN="true"
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
@@ -43,7 +47,7 @@ runs:
         python -m jupyter_releaser.actions.populate_release
 
     - id: finalize-release
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export RH_DRY_RUN="true"
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}

--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -20,6 +20,10 @@ inputs:
   steps_to_skip:
     description: "Comma separated list of steps to skip"
     required: false
+  shell:
+    description: "The shell being used for the action steps"
+    required: false
+    default: bash -eux {0}
 
 outputs:
   release_url:
@@ -33,7 +37,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
@@ -42,7 +46,7 @@ runs:
         fi
 
     - id: finalize-release
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export GITHUB_ACTOR=${{ github.triggering_actor }}
@@ -54,7 +58,7 @@ runs:
         python -m jupyter_releaser.actions.finalize_release
 
     - if: ${{ success() }}
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         echo "## Next Step" >> $GITHUB_STEP_SUMMARY
         echo "Verify the final release" >> $GITHUB_STEP_SUMMARY
@@ -67,7 +71,7 @@ runs:
         fi
 
     - if: ${{ failure() }}
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         echo "## Failure Message" >> $GITHUB_STEP_SUMMARY
         echo ":x: Failed to Publish the Draft Release Url:" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/populate-release/action.yml
+++ b/.github/actions/populate-release/action.yml
@@ -20,6 +20,10 @@ inputs:
   steps_to_skip:
     description: "Comma separated list of steps to skip"
     required: false
+  shell:
+    description: "The shell being used for the action steps"
+    required: false
+    default: bash -eux {0}
 
 outputs:
   release_url:
@@ -30,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
@@ -39,7 +43,7 @@ runs:
         fi
 
     - id: populate-release
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export GITHUB_ACTOR=${{ github.triggering_actor }}
@@ -51,7 +55,7 @@ runs:
         python -m jupyter_releaser.actions.populate_release
 
     - if: ${{ failure() }}
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         echo "## Failure Message" >> $GITHUB_STEP_SUMMARY
         echo ":x: Failed to Publish the Draft Release Url:" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/prep-release/action.yml
+++ b/.github/actions/prep-release/action.yml
@@ -31,6 +31,10 @@ inputs:
   since_last_stable:
     description: "Use PRs with activity since the last stable git tag"
     required: false
+  shell:
+    description: "The shell being used for the action steps"
+    required: false
+    default: bash -eux {0}
 outputs:
   release_url:
     description: "The html URL of the draft GitHub release"
@@ -39,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
@@ -48,7 +52,7 @@ runs:
         fi
 
     - id: prep-release
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export GITHUB_ACTOR=${{ github.triggering_actor }}
@@ -65,7 +69,7 @@ runs:
 
         python -m jupyter_releaser.actions.prep_release
 
-    - shell: bash -eux {0}
+    - shell: ${{ inputs.shell }}
       run: |
         echo "## Next Step" >> $GITHUB_STEP_SUMMARY
         echo "(Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/publish-changelog/action.yml
+++ b/.github/actions/publish-changelog/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "If set, do not make a PR"
     default: "false"
     required: false
+  shell:
+    description: "The shell being used for the action steps"
+    required: false
+    default: bash -eux {0}
 outputs:
   pr_url:
     description: "The html URL of the draft GitHub release"
@@ -22,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: install-releaser
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         # Install Jupyter Releaser from git unless we are testing Releaser itself
         if ! command -v jupyter-releaser &> /dev/null
@@ -31,7 +35,7 @@ runs:
         fi
 
     - id: publish-changelog
-      shell: bash -eux {0}
+      shell: ${{ inputs.shell }}
       run: |
         export GITHUB_ACCESS_TOKEN=${{ inputs.token }}
         export GITHUB_ACTOR=${{ github.triggering_actor }}
@@ -43,7 +47,7 @@ runs:
 
         python -m jupyter_releaser.actions.publish_changelog
 
-    - shell: bash -eux {0}
+    - shell: ${{ inputs.shell }}
       run: |
         echo "## Next Step" >> $GITHUB_STEP_SUMMARY
         echo "Merge the changelog update PR: ${{ steps.publish-changelog.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Problem

Discovered in https://github.com/voila-dashboards/voici/pull/107

It seems that when using a mamba-installed yarn (v3) it is not being picked up by the releaser. I understand the issue has to do with the shell being used in the jupyter-releaser action, so making this one configurable could allow to fix it