### PR TITLE
Emit a warning when uploading is skipped

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -434,6 +434,12 @@ def publish_assets(
                 # a PYPI_TOKEN_MAP will not be sanitized in output
                 util.retry(f"{twine_cmd} {name}", cwd=dist_dir, env=env, echo=True)
                 found = True
+            else:
+                warnings.warn(
+                    f"Python package name {pkg.name} does not match with name in "
+                    f"jupyter releaser config: {python_package_name}. Skipping uploading dist file {path}",
+                    stacklevel=2,
+                )
         elif suffix == ".tgz":
             # Ignore already published versions
             try:


### PR DESCRIPTION
* When py packages names are inconsistent between jupyter releaser config and wheel, uploading assets to PyPI will be silently skipped. We emit a warning now when this happens

* A unit test has been added to test the warning

Closes #554 