### PR TITLE
Do not require admin for publish changelog action

### DIFF
--- a/.github/actions/publish-changelog/action.yml
+++ b/.github/actions/publish-changelog/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: "If set, do not make a PR"
     default: "false"
     required: false
-  admin_check:
-    description: "Check if the user is a repo admin"
-    required: false
-    default: "true"
   shell:
     description: "The shell being used for the action steps"
     required: false
@@ -45,7 +41,7 @@ runs:
           export RH_BRANCH=${{ inputs.branch }}
         fi
         export RH_DRY_RUN=${{ inputs.dry_run }}
-        export RH_ADMIN_CHECK=${{ inputs.admin_check }}
+        export RH_ADMIN_CHECK=false
 
         python -m jupyter_releaser.actions.publish_changelog
 


### PR DESCRIPTION
This action is run with the credentials of the GitHub App, so it will not have admin credentials: https://github.com/jupyter/nbformat/actions/runs/8250694185/job/22565921338