### PR TITLE
Print out error for npm upload

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -448,6 +448,7 @@ def publish_assets(
                 stderr = e.stderr
                 if "EPUBLISHCONFLICT" in stderr or "previously published versions" in stderr:
                     continue
+                util.log(stderr)
                 raise e
             found = True
         else:


### PR DESCRIPTION
(if it is not a previously published version error)

https://github.com/jupyter-server/jupyter_releaser/issues/563

Of note, lack of the error message here has wasted a number of hours with other npm upload issues previously (e.g. when npm was down, or npm account was mis-configured).