### PR TITLE
Normalise package name before comparison

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -16,6 +16,7 @@ from subprocess import CalledProcessError
 from typing import Type, Union
 
 import mdformat
+from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version
 from pkginfo import SDist, Wheel
 
@@ -396,7 +397,7 @@ def publish_assets(
 
     res = python_package.split(":")
     python_package_path = res[0]
-    python_package_name = res[1].replace("-", "_") if len(res) == 2 else ""
+    python_package_name = canonicalize_name(res[1]) if len(res) == 2 else ""
 
     if release_url and len(glob(f"{dist_dir}/*.whl")):
         twine_token = python.get_pypi_token(release_url, python_package_path)
@@ -427,7 +428,7 @@ def publish_assets(
             dist: Union[Type[SDist], Type[Wheel]]
             dist = SDist if suffix == ".gz" else Wheel
             pkg = dist(path)
-            pkg_name = pkg.name.replace("-", "_")
+            pkg_name = canonicalize_name(pkg.name)
             if not python_package_name or python_package_name == pkg_name:
                 env = os.environ.copy()
                 env["TWINE_PASSWORD"] = twine_token

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -427,7 +427,8 @@ def publish_assets(
             dist: Union[Type[SDist], Type[Wheel]]
             dist = SDist if suffix == ".gz" else Wheel
             pkg = dist(path)
-            if not python_package_name or python_package_name == pkg.name:
+            pkg_name = pkg.name.replace("-", "_")
+            if not python_package_name or python_package_name == pkg_name:
                 env = os.environ.copy()
                 env["TWINE_PASSWORD"] = twine_token
                 # NOTE: Do not print the env since a twine token extracted from
@@ -436,7 +437,7 @@ def publish_assets(
                 found = True
             else:
                 warnings.warn(
-                    f"Python package name {pkg.name} does not match with name in "
+                    f"Python package name {pkg_name} does not match with name in "
                     f"jupyter releaser config: {python_package_name}. Skipping uploading dist file {path}",
                     stacklevel=2,
                 )


### PR DESCRIPTION
This should help with https://github.com/jupyterlab/jupyter-collaboration/issues/265#issuecomment-2058916408 - does it seem right? I always thought that dashes are preferred in package names over underscores and the https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#name gives an example of `spam-eggs`