### PR TITLE
Prepend tag with Python package name if multiple packages are defined

### DIFF
--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -377,9 +377,18 @@ def prep_git(ref, branch, repo, auth, username, git_url):
 def bump_version(version_spec, version_cmd, changelog_path, python_packages, tag_format):
     """Prep git and env variables and bump version"""
     prev_dir = os.getcwd()
-    for python_package in [p.split(":")[0] for p in python_packages]:
-        os.chdir(python_package)
-        lib.bump_version(version_spec, version_cmd, changelog_path, tag_format)
+    for package in python_packages:
+        package_path, package_name = (
+            package.split(":", maxsplit=2) if ":" in package else [package, None]
+        )
+        os.chdir(package_path)
+        lib.bump_version(
+            version_spec,
+            version_cmd,
+            changelog_path,
+            tag_format,
+            package_name=package_name if len(python_packages) > 1 else None,
+        )
         os.chdir(prev_dir)
 
 

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -23,7 +23,7 @@ from pkginfo import SDist, Wheel
 from jupyter_releaser import changelog, npm, python, util
 
 
-def bump_version(version_spec, version_cmd, changelog_path, tag_format):
+def bump_version(version_spec, version_cmd, changelog_path, tag_format, package_name=None):
     """Bump the version and verify new version"""
     util.bump_version(version_spec, version_cmd=version_cmd, changelog_path=changelog_path)
 
@@ -38,6 +38,8 @@ def bump_version(version_spec, version_cmd, changelog_path, tag_format):
 
     # Bail if tag already exists
     tag_name = tag_format.format(version=version)
+    if package_name:
+        tag_name = package_name + "-" + tag_name
     if tag_name in util.run("git --no-pager tag", quiet=True).splitlines():
         msg = f"Tag {tag_name} already exists!"
         msg += " To delete run: `git push --delete origin {tag_name}`"


### PR DESCRIPTION
This aims to alleviate https://github.com/jupyter-server/jupyter_releaser/issues/567#issuecomment-2067274319 by checking for package-specific tags. As of today it effectively, skips the check for already existing tags when:
- package names are defined for python packages, **and**
- there is more than one python package

It does not implement creating tags per Python package yet.