### PR TITLE
Remove the GitHub access token prerequisite

### DIFF
--- a/docs/source/how_to_guides/convert_repo_from_repo.md
+++ b/docs/source/how_to_guides/convert_repo_from_repo.md
@@ -8,7 +8,6 @@ See checklist below for details:
 
 - Markdown changelog
 - Bump version configuration (if using Python), for example [hatch](https://hatch.pypa.io/latest/)
-- [Access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to target GitHub repo to run GitHub Actions.
 - [Add a trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to your PyPI project
 - If needed, access token for [npm](https://docs.npmjs.com/creating-and-viewing-access-tokens).
 


### PR DESCRIPTION
GitHub authentication is now done through an application.