### PR TITLE
Fix code indentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ To install the latest release locally, make sure you have
 [pip installed](https://pip.readthedocs.io/en/stable/installing/) and run:
 
 ```bash
-    pip install git+https://github.com/jupyter-server/jupyter_releaser
+pip install git+https://github.com/jupyter-server/jupyter_releaser
 ```
 
 ## Library Usage
 
 ```bash
-    jupyter-releaser --help
-    jupyter-releaser build-python --help
-    jupyter-releaser check-npm --help
+jupyter-releaser --help
+jupyter-releaser build-python --help
+jupyter-releaser check-npm --help
 ```
 
 ## Checklist for Adoption


### PR DESCRIPTION
The current indentation looks a bit off:

![image](https://github.com/user-attachments/assets/f7789c54-d2ea-4934-a880-8245c1fbfeb6)
