### PR TITLE
Add FAQ section about publish to `npm` only

### DIFF
--- a/docs/source/faq/index.md
+++ b/docs/source/faq/index.md
@@ -46,6 +46,15 @@ As a workaround, you can skip the `check-python` step with the following release
 skip = ["check-python"]
 ```
 
+## How to only publish to `npm`?
+
+If you would like to use the Jupyter Releaser to publish to `npm` only, you can configure the releaser to skip the `build-python` step:
+
+```toml
+[tool.jupyter-releaser]
+skip = ["build-python"]
+```
+
 ## My changelog is out of sync
 
 Create a new manual PR to fix the PR and re-orient the changelog entry markers.


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_releaser/issues/508

For now the FAQ seems to be a good place to put this kind of information. But it could be moved to another section of the docs later if needed.