### PR TITLE
Add link to the blog post to the documentation

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,6 +2,8 @@
 
 **Jupyter Releaser** contains a set of helper scripts and GitHub Actions to aid in automated releases of Python and npm packages.
 
+## Documentation
+
 ```{toctree}
 :maxdepth: 2
 
@@ -17,7 +19,11 @@ faq/index
 reference/changelog
 ```
 
-# Indices and tables
+### Blog post
+
+For a high level overview of the Jupyter Releaser, check out [this post](https://blog.jupyter.org/automate-your-releases-with-the-jupyter-releaser-701e7b9841e6) on the Jupyter blog (published on October 29th, 2024).
+
+## Indices and tables
 
 - {ref}`genindex`
 - {ref}`modindex`


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_releaser/issues/459

This provides a high level overview of the releaser. It also makes it easier to find the link to the blog post from the docs.