### PR TITLE
Pin `pypiserver` to v2.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,10 @@ jobs:
       - lint
       - check_local_actions
       - test_minimum_versions
-      - test_prereleases
+      # disabled until we can use pypiserver 2.3.x
+      # which supports Python 3.13, see
+      # https://github.com/pypiserver/pypiserver/issues/630
+      # - test_prereleases
       - generate_changelog
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "mdformat",
     "packaging",
     "pkginfo",
-    "pypiserver==2.3.0",
+    "pypiserver==2.2.0",
     "pipx",
     "requests",
     "requests_cache",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "mdformat",
     "packaging",
     "pkginfo",
-    "pypiserver",
+    "pypiserver==2.3.0",
     "pipx",
     "requests",
     "requests_cache",


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_releaser/issues/595, workaround for https://github.com/pypiserver/pypiserver/issues/630.

Closes https://github.com/jupyter-server/jupyter_releaser/pull/594