### PR TITLE
Fix for displaying help for the `build_python` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ jupyter-releaser --help
 To run the Python tests, use:
 
 ```bash
-pytest
+hatch run test:test
 ```
 
 ## Documentation

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -21,7 +21,7 @@ class ReleaseHelperGroup(click.Group):
         """Handle jupyter-releaser config while invoking a command"""
         # Get the command name and make sure it is valid
         cmd_name = ctx.protected_args[0]
-        if cmd_name not in self.commands:
+        if cmd_name not in self.commands or "--help" in ctx.args:
             super().invoke(ctx)
 
         if cmd_name == "list-envvars":
@@ -343,7 +343,6 @@ def add_options(options):
 
 def use_checkout_dir():
     """Use the checkout dir created by prep-git"""
-
     def inner(func):
         ReleaseHelperGroup._needs_checkout_dir[func.__name__] = True
         return func

--- a/jupyter_releaser/cli.py
+++ b/jupyter_releaser/cli.py
@@ -343,6 +343,7 @@ def add_options(options):
 
 def use_checkout_dir():
     """Use the checkout dir created by prep-git"""
+
     def inner(func):
         ReleaseHelperGroup._needs_checkout_dir[func.__name__] = True
         return func


### PR DESCRIPTION
I wanted to run the command in bar folder

```
jupyter-releaser build-python --help
```

This line is in the `README.md`, so it should work right away.

But it gave an error

```
  File "/home/rakhmaevao/Projects/jupyter_releaser/jupyter_releaser/cli.py", line 44, in invoke
    raise ValueError(msg)
ValueError: Please run prep-git first
```

I fixed it.

Also the command to run tests from the `CONTRIBUTING.md` file did not work. But another command works. I fixed the `CONTRIBUTING.md` file.