### PR TITLE
Check for `npm` error code 409 to skip previously published packages in private registries

### DIFF
--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -450,7 +450,7 @@ def publish_assets(
                 util.run(f"{npm_cmd} {name}", cwd=dist_dir, quiet=True, quiet_error=True, echo=True)
             except CalledProcessError as e:
                 stderr = e.stderr
-                if "EPUBLISHCONFLICT" in stderr or "previously published versions" in stderr:
+                if "E409" in stderr or "EPUBLISHCONFLICT" in stderr or "previously published versions" in stderr:
                     continue
                 util.log(stderr)
                 raise e

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -450,7 +450,11 @@ def publish_assets(
                 util.run(f"{npm_cmd} {name}", cwd=dist_dir, quiet=True, quiet_error=True, echo=True)
             except CalledProcessError as e:
                 stderr = e.stderr
-                if "E409" in stderr or "EPUBLISHCONFLICT" in stderr or "previously published versions" in stderr:
+                if (
+                    "E409" in stderr
+                    or "EPUBLISHCONFLICT" in stderr
+                    or "previously published versions" in stderr
+                ):
                     continue
                 util.log(stderr)
                 raise e


### PR DESCRIPTION
This PR fixes an issue where previously published packages are not recognized for other npm registries, such as GitHub packages.
Closes #603 .