### PR TITLE
Update to `github-activity>=1.1.1`, drop Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 ]
 urls = {Homepage = "https://jupyter.org"}
 requires-python = ">=3.10"


### PR DESCRIPTION
The `pyproject.toml` was currently pining on the `0.2` version.

We should consider updating the dependency range, so we can pick up the latest bug fixes more easily.

This also requires dropping support for Python 3.9.

**Changes**

- [x] Update to `github-activity==1.1.1`
- [x] Drop support for Python 3.9