### PR TITLE
Handle `github-activity>=1.1.4`

### DIFF
--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -123,16 +123,23 @@ def get_version_entry(
     if ignored_contributors is None:
         ignored_contributors = DEFAULT_IGNORED_CONTRIBUTORS
 
-    md = generate_activity_md(
-        repo,
-        since=since,
-        until=until,
-        kind="pr",
-        heading_level=2,
-        auth=auth,
-        branch=branch,
-        ignored_contributors=ignored_contributors,
-    )
+    try:
+        md = generate_activity_md(
+            repo,
+            since=since,
+            until=until,
+            kind="pr",
+            heading_level=2,
+            auth=auth,
+            branch=branch,
+            ignored_contributors=ignored_contributors,
+        )
+    except ValueError as e:
+        # github-activity >= 1.1.4 raises ValueError when no activity is found
+        if "No activity found" in str(e):
+            util.log("No PRs found")
+            return f"## {version}\n\nNo merged PRs"
+        raise
 
     if not md:
         util.log("No PRs found")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -189,6 +189,29 @@ def test_get_empty_changelog(py_package, mocker):
     assert "...None" not in resp
 
 
+def test_get_changelog_no_activity_error(py_package, mocker):
+    """Test handling of ValueError raised by github-activity >= 1.1.4 when no activity is found."""
+    mocked_gen = mocker.patch("jupyter_releaser.changelog.generate_activity_md")
+    mocked_gen.side_effect = ValueError("No activity found for baz/bar between v0.2.4 and None.")
+    branch = "foo"
+    util.run("git branch baz/bar")
+    ref = "heads/baz/bar"
+    resp = changelog.get_version_entry(ref, branch, "baz/bar", "0.2.5", since="v0.2.4")
+    mocked_gen.assert_called_with(
+        "baz/bar",
+        since="v0.2.4",
+        until=None,
+        kind="pr",
+        heading_level=2,
+        auth=None,
+        branch=branch,
+        ignored_contributors=DEFAULT_IGNORED_CONTRIBUTORS,
+    )
+
+    assert "## 0.2.5" in resp
+    assert "No merged PRs" in resp
+
+
 def test_splice_github_entry(py_package, mocker):
     version = util.get_version()
 


### PR DESCRIPTION
As noticed in https://github.com/executablebooks/github-activity/pull/162#discussion_r2653707877, `github-activity>=1.1.4` now throws when no results are returned.

This leads to the `check_release` job sometimes failing on CI, usually right after a release (since there is no new PR):

https://github.com/jtpio/jupyterlite-server-contents/actions/runs/20604073817/job/59175936047

```
ValueError: No activity found for <repo-name> between v0.1.1 and None.
```

We can handle this new behavior by being more defensive.