### PR TITLE
Pin `ruamel.yaml<0.19` in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
   "pytest-mock",
   "pytest-xdist[psutil]",
   "uvicorn",
-  "ruamel.yaml"
+  "ruamel.yaml<0.19"
 ]
 
 [project.scripts]


### PR DESCRIPTION
CI passed for https://github.com/jupyter-server/jupyter_releaser/pull/637.

But started to fail when the PR was merged: 472d8f7b56dab7b69cedbafd99fb4d18491b85c4

```
        if check and result.returncode != 0:
>           raise subprocess.CalledProcessError(
                result.returncode, cmd, output=result.stdout, stderr=result.stderr
            )
E           subprocess.CalledProcessError: Command 'pre-commit run -a' returned non-zero exit status 1.

args       = 'pre-commit run -a'
check      = True
cmd        = 'pre-commit run -a'
kwargs     = {'check': True}
loop       = <_UnixSelectorEventLoop running=False closed=False debug=False>
```

This appears to be related to the latest `ruamel.yaml` released a couple of days ago:

- https://pypi.org/project/ruamel.yaml/0.19.0/
- https://yaml.dev/doc/ruamel.yaml/

The simplest would be to pin for now and investigate supporting the new version separately.