### PR TITLE
Handle `github-activity` reporting no activity on the target branch

### DIFF
--- a/jupyter_releaser/changelog.py
+++ b/jupyter_releaser/changelog.py
@@ -135,8 +135,11 @@ def get_version_entry(
             ignored_contributors=ignored_contributors,
         )
     except ValueError as e:
-        # github-activity >= 1.1.4 raises ValueError when no activity is found
-        if "No activity found" in str(e):
+        # github-activity >= 1.1.4 raises ValueError when there are no PRs to
+        # include — either no activity in the range at all, or activity exists
+        # but none of it targets the requested branch.
+        msg = str(e)
+        if "No activity found" in msg or "Found activity, but none for the --branch target" in msg:
             util.log("No PRs found")
             return f"## {version}\n\nNo merged PRs"
         raise


### PR DESCRIPTION
Follow-up to https://github.com/jupyter-server/jupyter_releaser/pull/637

Handle the other case when there is a more recent change on the repo, but not on the target branch (as seen https://github.com/jupyterlite/jupyterlite/pull/1909).