### PR TITLE
Auto-detect changelog `since` from last stable tag for final releases

### DIFF
--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -19,6 +19,7 @@ from glob import glob
 from io import BytesIO
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, check_output
+from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -440,12 +441,10 @@ def is_final_version_spec(version_spec: str) -> bool:
         parsed = parse_version(version_spec)
     except Exception:
         return False
-    if not isinstance(parsed, Version):
-        return False
     return not parsed.is_prerelease and not parsed.is_devrelease
 
 
-def should_use_since_last_stable(version_spec: str, branch: str | None = None) -> bool:
+def should_use_since_last_stable(version_spec: str, branch: Optional[str] = None) -> bool:
     """Auto-detect when changelog generation should walk back to the last stable tag."""
     if not is_final_version_spec(version_spec):
         return False

--- a/jupyter_releaser/util.py
+++ b/jupyter_releaser/util.py
@@ -416,13 +416,43 @@ def get_latest_tag(source, since_last_stable=False):
     tags = tags.splitlines()
 
     if since_last_stable:
-        stable_tag = re.compile(r"\d+\.\d+\.\d+$")
-        tags = [t for t in tags if re.search(stable_tag, t)]
+        tags = [t for t in tags if is_stable_tag(t)]
         if not tags:
             return ""
         return tags[0]
 
     return tags[0]
+
+
+def is_stable_tag(tag: str) -> bool:
+    """Check if a git tag name looks like a stable release tag."""
+    return bool(re.search(r"\d+\.\d+\.\d+$", tag))
+
+
+def is_final_version_spec(version_spec: str) -> bool:
+    """Check if a version specifier looks like a stable/final version."""
+    if not version_spec:
+        return False
+    normalized = version_spec.strip().lower()
+    if normalized == "release":
+        return True
+    try:
+        parsed = parse_version(version_spec)
+    except Exception:
+        return False
+    if not isinstance(parsed, Version):
+        return False
+    return not parsed.is_prerelease and not parsed.is_devrelease
+
+
+def should_use_since_last_stable(version_spec: str, branch: str | None = None) -> bool:
+    """Auto-detect when changelog generation should walk back to the last stable tag."""
+    if not is_final_version_spec(version_spec):
+        return False
+    latest_tag = get_latest_tag(branch)
+    if not latest_tag:
+        return False
+    return not is_stable_tag(latest_tag)
 
 
 def get_first_commit(source):
@@ -645,6 +675,16 @@ def handle_since() -> str:
     os.chdir(CHECKOUT_NAME)
     since_last_stable_env = os.environ.get("RH_SINCE_LAST_STABLE", "")
     since_last_stable = since_last_stable_env.lower() == "true"
+
+    if not since_last_stable and should_use_since_last_stable(
+        os.environ.get("RH_VERSION_SPEC", ""), os.environ.get("RH_BRANCH")
+    ):
+        since_last_stable = True
+        log(
+            "Auto-detected final release after a prerelease tag; "
+            "using the last stable tag for RH_SINCE."
+        )
+
     log(f"Since last stable? {since_last_stable}")
     since = get_latest_tag(os.environ.get("RH_BRANCH"), since_last_stable)
     if since:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -436,3 +436,57 @@ def test_handle_since(npm_package, runner):
     run("git tag v1.0.1", cwd=util.CHECKOUT_NAME)
     since = util.handle_since()
     assert since == "v1.0.1"
+
+
+def test_handle_since_auto_uses_last_stable_for_final_release(npm_package, runner):
+    runner(["prep-git", "--git-url", npm_package])
+    run("git tag v1.0.0", cwd=util.CHECKOUT_NAME)
+    time.sleep(1)
+    Path(util.CHECKOUT_NAME, "beta.txt").write_text("beta\n", encoding="utf-8")
+    run("git add beta.txt", cwd=util.CHECKOUT_NAME)
+    run('git commit -m "beta prep"', cwd=util.CHECKOUT_NAME)
+    run("git tag v1.1.0b0", cwd=util.CHECKOUT_NAME)
+    os.environ["RH_BRANCH"] = run("git branch --show-current", cwd=util.CHECKOUT_NAME)
+    assert util.get_latest_tag(os.environ["RH_BRANCH"]) == "v1.1.0b0"
+
+    os.environ["RH_VERSION_SPEC"] = "1.1.0"
+    os.environ["RH_SINCE_LAST_STABLE"] = "false"
+
+    since = util.handle_since()
+    assert since == "v1.0.0"
+
+
+def test_handle_since_auto_keeps_latest_prerelease_for_prerelease_release(npm_package, runner):
+    runner(["prep-git", "--git-url", npm_package])
+    run("git tag v1.0.0", cwd=util.CHECKOUT_NAME)
+    time.sleep(1)
+    Path(util.CHECKOUT_NAME, "beta.txt").write_text("beta\n", encoding="utf-8")
+    run("git add beta.txt", cwd=util.CHECKOUT_NAME)
+    run('git commit -m "beta prep"', cwd=util.CHECKOUT_NAME)
+    run("git tag v1.1.0b0", cwd=util.CHECKOUT_NAME)
+    os.environ["RH_BRANCH"] = run("git branch --show-current", cwd=util.CHECKOUT_NAME)
+    assert util.get_latest_tag(os.environ["RH_BRANCH"]) == "v1.1.0b0"
+
+    os.environ["RH_VERSION_SPEC"] = "1.1.0b1"
+    os.environ["RH_SINCE_LAST_STABLE"] = "false"
+
+    since = util.handle_since()
+    assert since == "v1.1.0b0"
+
+
+def test_handle_since_auto_uses_last_stable_for_release_keyword(npm_package, runner):
+    runner(["prep-git", "--git-url", npm_package])
+    run("git tag v1.0.0", cwd=util.CHECKOUT_NAME)
+    time.sleep(1)
+    Path(util.CHECKOUT_NAME, "beta.txt").write_text("beta\n", encoding="utf-8")
+    run("git add beta.txt", cwd=util.CHECKOUT_NAME)
+    run('git commit -m "beta prep"', cwd=util.CHECKOUT_NAME)
+    run("git tag v1.1.0rc1", cwd=util.CHECKOUT_NAME)
+    os.environ["RH_BRANCH"] = run("git branch --show-current", cwd=util.CHECKOUT_NAME)
+    assert util.get_latest_tag(os.environ["RH_BRANCH"]) == "v1.1.0rc1"
+
+    os.environ["RH_VERSION_SPEC"] = "release"
+    os.environ["RH_SINCE_LAST_STABLE"] = "false"
+
+    since = util.handle_since()
+    assert since == "v1.0.0"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -446,8 +446,7 @@ def test_handle_since_auto_uses_last_stable_for_final_release(npm_package, runne
     run("git add beta.txt", cwd=util.CHECKOUT_NAME)
     run('git commit -m "beta prep"', cwd=util.CHECKOUT_NAME)
     run("git tag v1.1.0b0", cwd=util.CHECKOUT_NAME)
-    os.environ["RH_BRANCH"] = run("git branch --show-current", cwd=util.CHECKOUT_NAME)
-    assert util.get_latest_tag(os.environ["RH_BRANCH"]) == "v1.1.0b0"
+    os.environ["RH_BRANCH"] = "bar"
 
     os.environ["RH_VERSION_SPEC"] = "1.1.0"
     os.environ["RH_SINCE_LAST_STABLE"] = "false"
@@ -464,8 +463,7 @@ def test_handle_since_auto_keeps_latest_prerelease_for_prerelease_release(npm_pa
     run("git add beta.txt", cwd=util.CHECKOUT_NAME)
     run('git commit -m "beta prep"', cwd=util.CHECKOUT_NAME)
     run("git tag v1.1.0b0", cwd=util.CHECKOUT_NAME)
-    os.environ["RH_BRANCH"] = run("git branch --show-current", cwd=util.CHECKOUT_NAME)
-    assert util.get_latest_tag(os.environ["RH_BRANCH"]) == "v1.1.0b0"
+    os.environ["RH_BRANCH"] = "bar"
 
     os.environ["RH_VERSION_SPEC"] = "1.1.0b1"
     os.environ["RH_SINCE_LAST_STABLE"] = "false"
@@ -482,8 +480,7 @@ def test_handle_since_auto_uses_last_stable_for_release_keyword(npm_package, run
     run("git add beta.txt", cwd=util.CHECKOUT_NAME)
     run('git commit -m "beta prep"', cwd=util.CHECKOUT_NAME)
     run("git tag v1.1.0rc1", cwd=util.CHECKOUT_NAME)
-    os.environ["RH_BRANCH"] = run("git branch --show-current", cwd=util.CHECKOUT_NAME)
-    assert util.get_latest_tag(os.environ["RH_BRANCH"]) == "v1.1.0rc1"
+    os.environ["RH_BRANCH"] = "bar"
 
     os.environ["RH_VERSION_SPEC"] = "release"
     os.environ["RH_SINCE_LAST_STABLE"] = "false"


### PR DESCRIPTION
Closes #652 

This PR improves changelog range selection for release workflows by automatically using the last stable tag as `since` when publishing a final release and the latest tag is a prerelease (beta/rc), while preserving explicit user overrides and prerelease behavior. It also includes support for keyword-based finalization (version_spec=release).