### PR TITLE
Add release_tag as output of finalize-release

### DIFF
--- a/.github/actions/finalize-release/action.yml
+++ b/.github/actions/finalize-release/action.yml
@@ -33,6 +33,9 @@ outputs:
   release_url:
     description: "The html URL of the GitHub release"
     value: ${{ steps.finalize-release.outputs.release_url }}
+  release_tag:
+    description: "The tag name of the GitHub release"
+    value: ${{ steps.finalize-release.outputs.release_tag }}
   pr_url:
     description: "The html URL of the forwardport PR if applicable"
     value: ${{ steps.finalize-release.outputs.pr_url }}

--- a/jupyter_releaser/lib.py
+++ b/jupyter_releaser/lib.py
@@ -496,6 +496,7 @@ def publish_release(auth, dry_run, release_url, silent):
 
     # Set the GitHub action output
     util.actions_output("release_url", release.html_url)
+    util.actions_output("release_tag", release.tag_name)
 
 
 def prep_git(ref, branch, repo, auth, username, url):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -752,13 +752,20 @@ def test_publish_assets_npm_prerelease_dry_run(npm_dist_prerelease, runner, mock
     runner(["publish-assets", "--dist-dir", dist_dir, "--dry-run"])
 
 
-def test_publish_release(npm_dist, runner, mocker, mock_github, draft_release):
+def test_publish_release(npm_dist, runner, mocker, mock_github, draft_release, tmp_path):
     os.environ["RH_RELEASE_URL"] = draft_release
+    github_output = tmp_path / "github_output"
+    os.environ["GITHUB_OUTPUT"] = str(github_output)
     runner(["publish-release"])
 
     log = get_log()
     assert "before-publish-release" in log
     assert "after-publish-release" in log
+
+    tag = draft_release.rsplit("/", 1)[-1]
+    outputs = github_output.read_text(encoding="utf-8")
+    assert f"release_url={draft_release}" in outputs
+    assert f"release_tag={tag}" in outputs
 
 
 def test_config_file(py_package, runner, mocker, git_prep):


### PR DESCRIPTION
This is useful in post-release steps, e.g. to announce the release on a group chat or build a PyPI URI.