### PR TITLE
Bump mypy python_version to 3.10 to fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         exclude: '.pre-commit-config.yaml'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.8.0"
+    rev: "v1.12.0"
     hooks:
       - id: mypy
         files: "^jupyter_releaser"

--- a/jupyter_releaser/npm.py
+++ b/jupyter_releaser/npm.py
@@ -19,7 +19,7 @@ PACKAGE_JSON = util.PACKAGE_JSON
 # Python 3.12+ gives a deprecation warning if TarFile.extraction_filter is None.
 # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
 if hasattr(tarfile, "fully_trusted_filter"):
-    tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)  # type:ignore[assignment]
+    tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)
 
 
 def build_dist(package, dist_dir):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ source = ["jupyter_releaser"]
 
 [tool.mypy]
 files = "jupyter_releaser"
-python_version = "3.8"
+python_version = "3.10"
 strict = true
 disable_error_code  = [ "no-untyped-call", "no-untyped-def"]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]


### PR DESCRIPTION
Fixes CI on pull requests.

---

Bumping mypy's python_version from 3.8 to 3.10 surfaces two issues that the 3.8 run masked (at 3.8 mypy aborted on click's match-statement syntax before checking the package):

- npm.py: the type:ignore[assignment] on TarFile.extraction_filter is no longer needed
- mock_github.py's handlers take a bare `Request`, which strict's disallow_any_generics flagged as missing a type parameter. starlette 1.3 makes Request generic over StateT, but StateT carries a PEP 696 default (default=State), so a bare Request is correct. mypy only honors TypeVar defaults since 1.12, while the pre-commit hook pinned v1.8.0. Bump the pin to v1.12.0 so the bare Request type-checks.